### PR TITLE
Feature: `loop` construct in scenario specs

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -20,7 +20,16 @@ function HttpEngine(config) {
 }
 
 HttpEngine.prototype.step = function step(requestSpec, ee) {
+  let self = this;
   let config = this.config;
+
+  if (requestSpec.loop) {
+    let steps = _.map(requestSpec.loop, function(rs) {
+      return self.step(rs, ee);
+    });
+
+    return engineUtil.createLoopWithCount(requestSpec.count || -1, steps);
+  }
 
   var f = function(context, callback) {
     let method = _.keys(requestSpec)[0].toUpperCase();

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -4,11 +4,13 @@ const debug = require('debug')('engine_util');
 const hogan = require('hogan.js');
 const traverse = require('traverse');
 const esprima = require('esprima');
-const _ = require('lodash');
+const L = require('lodash');
 const vm = require('vm');
+const A = require('async');
 
 module.exports = {
   createThink: createThink,
+  createLoopWithCount: createLoopWithCount,
   template: template,
   evil: evil
 };
@@ -24,6 +26,31 @@ function createThink(requestSpec) {
   };
 
   return f;
+}
+
+function createLoopWithCount(count, steps) {
+  return function aLoop(context, callback) {
+    let i = 0;
+    let newContext = context;
+    A.whilst(
+      function test() {
+        return i < count;
+      },
+      function repeated(cb) {
+        let zero = function(cb2) {
+          return cb2(null, newContext);
+        };
+        let steps2 = L.flatten([zero, steps]);
+        A.waterfall(steps2, function(err, context2) {
+          i++;
+          newContext = context2;
+          return cb(err, context2);
+        });
+      },
+      function(err, finalContext) {
+        return callback(err, finalContext);
+      });
+  };
 }
 
 function template(o, context) {
@@ -47,7 +74,7 @@ function template(o, context) {
       if (syntax.body && syntax.body.length === 1 &&
           syntax.body[0].type === 'ExpressionStatement') {
         let funcName = syntax.body[0].expression.callee.name;
-        let args = _.map(syntax.body[0].expression.arguments, function(arg) {
+        let args = L.map(syntax.body[0].expression.arguments, function(arg) {
           return arg.value;
         });
         if (funcName in context.funcs) {

--- a/lib/engine_ws.js
+++ b/lib/engine_ws.js
@@ -4,7 +4,7 @@ const async = require('async');
 const _ = require('lodash');
 const WebSocket = require('ws');
 const debug = require('debug')('ws');
-
+const engineUtil = require('./engine_util');
 module.exports = WSEngine;
 
 function WSEngine(config) {
@@ -12,6 +12,15 @@ function WSEngine(config) {
 }
 
 WSEngine.prototype.step = function (requestSpec, ee) {
+
+  if (requestSpec.loop) {
+    let steps = _.map(requestSpec.loop, function(rs) {
+      return self.step(rs, ee);
+    });
+
+    return engineUtil.createLoopWithCount(requestSpec.count || -1, steps);
+  }
+
   let f = function(context, callback) {
     ee.emit('request');
     let startedAt = process.hrtime();

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -289,7 +289,7 @@ function runScenario(script, intermediate, aggregate) {
     if (err) {
       debug(err);
       //debug('Scenario aborted due to error');
-      cancelledRequests.inc(context._pendingRequests);
+      //cancelledRequests.inc(context._pendingRequests);
     } else {
       //debug('Scenario completed');
       //debug(context);

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 require('./unit/index');
 require('./test_multiple_payloads');
 require('./test_misc');
+require('./test_loop');
 
 //require('./test_worker_http');
 //require('./test_environments.js');

--- a/test/scripts/loop.json
+++ b/test/scripts/loop.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "target": "http://localhost:3003",
+    "phases": [
+      {"duration": 10, "arrivalRate": 20}
+    ],
+    "statsInterval": 1
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {
+          "loop": [
+            {"get": {"url": "/"}}
+          ],
+          "count": 100
+        }
+      ]
+    }
+  ]
+}

--- a/test/targets/simple.js
+++ b/test/targets/simple.js
@@ -103,7 +103,7 @@ server.register({
       setInterval(function() {
         console.log(new Date());
         console.log('REQUEST_COUNT = %s', REQUEST_COUNT);
-      }, 20 * 1000 * 20);
+      }, 20 * 1000);
     });
   }
 });

--- a/test/test_loop.js
+++ b/test/test_loop.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const test = require('tape');
+const runner = require('../lib/runner').runner;
+const L = require('lodash');
+
+test('loop', (t) => {
+  const script = require('./scripts/loop.json');
+
+  let ee = runner(script);
+  ee.on('done', (stats) => {
+    let scenarios = stats.aggregate.scenariosCompleted;
+    let requests = stats.aggregate.requestsCompleted;
+    let loopCount = script.scenarios[0].flow[0].count;
+    let expected = scenarios * loopCount;
+    t.assert(
+      requests === expected,
+      'Should have ' + loopCount + ' requests for each completed scenario');
+    t.end();
+  });
+  ee.run();
+});


### PR DESCRIPTION
This change adds supporting for looping through an arbitrary sequence of steps in a scenario definition.

Example: https://gist.github.com/hassy/6434454403cfb0285f64