### PR TITLE
Add XML/XPath support

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -33,6 +33,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
   }
 
   var f = function(context, callback) {
+
     let method = _.keys(requestSpec)[0].toUpperCase();
     let params = requestSpec[method.toLowerCase()];
     let uri = maybePrependBase(template(params.url, context), config);
@@ -90,52 +91,114 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
         return callback(err, context);
       }
 
-      if (res.headers['content-type'] &&
-          res.headers['content-type'].match(/^application\/json/) &&
-          (params.match || params.capture)) {
-        try {
-          let r;
-          if (typeof res.body === 'string') {
-            r = JSON.parse(res.body);
-          } else {
-            r = res.body;
-          }
-
-          if (params.match) {
-            let result = jsonpath.eval(r, params.match.json)[0];
-            let value = template(params.match.value, context);
-
-            if (result !== value) {
-              // abort the scenario
-              // return callback(err, context);
-            } else {
-              debug('match: %s matched %s in response', params.match.json, value);
-              ee.emit('match');
+      if (params.capture || params.match) {
+        if (isJSON(res)) {
+          parseJSON(res.body, function(err2, r) {
+            if (err2) {
+              let errCode = err.code || err.message;
+              ee.emit('error', errCode);
+              debug(err);
+              // this aborts the scenario
+              return callback(err, context);
             }
-          }
 
-          if (params.capture) {
-            let capturedVal = jsonpath.eval(r, params.capture.json)[0];
-            context.vars[params.capture.as] = capturedVal;
+            if (params.match) {
+              let result = jsonpath.eval(r, params.match.json)[0];
+              let value = template(params.match.value, context);
+              debug('match: %s, expected: %s, got: %s', params.match.json, value, result);
 
-            debug('capture: %s = %s', params.capture.as, capturedVal);
-
-            if (params.capture.transform) {
-              let transformedVal = engineUtil.evil(
-                context.vars,
-                params.capture.transform);
-              context.vars[params.capture.as] = transformedVal;
-              debug('transform: %s = %s', params.capture.as, context.vars[params.capture.as]);
+              if (result !== value) {
+                ee.emit('match', false, {
+                  expected: value,
+                  got: result,
+                  request: requestParams
+                });
+                if (params.match.strict) {
+                  return callback(null, context);
+                }
+              } else {
+                ee.emit('match', true);
+              }
             }
-          }
-          context.vars.$ = r;
-        } catch (e) {
+
+            if (params.capture) {
+              let capturedVal = jsonpath.eval(r, params.capture.json)[0];
+              context.vars[params.capture.as] = capturedVal;
+
+              debug('capture: %s = %s', params.capture.as, capturedVal);
+
+              if (params.capture.transform) {
+                let transformedVal = engineUtil.evil(
+                  context.vars,
+                  params.capture.transform);
+                context.vars[params.capture.as] = transformedVal;
+                debug('transform: %s = %s',
+                      params.capture.as, context.vars[params.capture.as]);
+              }
+            }
+
+            context.vars.$ = r;
+            context._successCount++;
+            context._pendingRequests--;
+            return callback(null, context);
+          });
+        } else if (isXML(res)) {
+          parseXML(res.body, function(err2, doc) {
+            if (err2) {
+              let errCode = err.code || err.message;
+              ee.emit('error', errCode);
+              debug(err);
+              // this aborts the scenario
+              return callback(err, context);
+            }
+
+            if (params.match) {
+              let result = doc.get(params.match.xpath).text();
+              let value = template(params.match.value, context);
+              debug('match: %s, expected: %s, got: %s', params.match.xpath, value, result);
+              if (result !== value) {
+                ee.emit('match', false, {
+                  expected: value,
+                  got: result,
+                  request: requestParams
+                });
+                if (params.match.strict) {
+                  return callback(null, context);
+                }
+              } else {
+                ee.emit('match', true);
+              }
+            }
+            if (params.capture) {
+              let capturedVal = doc.get(params.capture.xpath).text();
+              context.vars[params.capture.as] = capturedVal;
+              debug('capture: %s = %s', params.capture.as, capturedVal);
+              if (params.capture.transform) {
+                let transformedVal = engineUtil.evil(
+                  context.vars,
+                  params.capture.transform);
+                context.vars[params.capture.as] = transformedVal;
+                debug('transform: %s = %s',
+                      params.capture.as, context.vars[params.capture.as]);
+              }
+            }
+
+            context.vars.$ = body; // inconsistency - string here, json object when json
+            context._successCount++;
+            context._pendingRequests--;
+            return callback(null, context);
+          });
+        } else {
+          // FIXME: We are trying to match on something that we cannot parse.
+          context._successCount++;
+          context._pendingRequests--;
+          return callback(null, context);
         }
+      } else {
+        context._successCount++;
+        context._pendingRequests--;
+        return callback(null, context);
       }
-
-      context._successCount++;
-      context._pendingRequests--;
-      return callback(null, context);
     })
     .on('request', function(req) {
       ee.emit('request');
@@ -206,7 +269,6 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
 };
 
 function maybePrependBase(uri, config) {
-
   if (_.startsWith(uri, '/')) {
     return config.target + uri;
   } else {
@@ -221,4 +283,52 @@ function lowcaseKeys(h) {
   return _.transform(h, function(result, v, k) {
     result[k.toLowerCase()] = v;
   });
+}
+
+/*
+ * Given a response object determine if it's JSON
+ */
+function isJSON(res) {
+  debug('isJSON: content-type = %s', res.headers['content-type']);
+  return (res.headers['content-type'] &&
+          /^application\/json/.test(res.headers['content-type']));
+}
+
+/*
+ * Given a response object determine if it's some kind of XML
+ */
+function isXML(res) {
+  return (res.headers['content-type'] &&
+          (/^[a-zA-Z]+\/xml/.test(res.headers['content-type']) ||
+           /^[a-zA-Z]+\/[a-zA-Z]+\+xml/.test(res.headers['content-type'])));
+
+}
+
+/*
+ * Wrap JSON.parse in a callback
+ */
+function parseJSON(body, callback) {
+  let r;
+  try {
+    if (typeof body === 'string') {
+      r = JSON.parse(body);
+    } else {
+      r = body;
+    }
+    return callback(null, r);
+  } catch(err) {
+    return callback(err, null);
+  }
+}
+
+/*
+ * Wrap XML parser in a callback
+ */
+function parseXML(body, callback) {
+  try {
+    let doc = xml.parseXml(body);
+    return callback(null, doc);
+  } catch(err) {
+    return callback(err, null);
+  }
 }

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -12,6 +12,7 @@ const template = engineUtil.template;
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
+const xml = require('libxmljs');
 
 module.exports = HttpEngine;
 
@@ -90,7 +91,8 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
       }
 
       if (res.headers['content-type'] &&
-          res.headers['content-type'].match(/^application\/json/)) {
+          res.headers['content-type'].match(/^application\/json/) &&
+          (params.match || params.capture)) {
         try {
           let r;
           if (typeof res.body === 'string') {

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -92,109 +92,76 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
       }
 
       if (params.capture || params.match) {
+        let parser;
+        let extractor;
         if (isJSON(res)) {
-          parseJSON(res.body, function(err2, r) {
-            if (err2) {
-              let errCode = err.code || err.message;
-              ee.emit('error', errCode);
-              debug(err);
-              // this aborts the scenario
-              return callback(err, context);
-            }
-
-            if (params.match) {
-              let result = jsonpath.eval(r, params.match.json)[0];
-              let value = template(params.match.value, context);
-              debug('match: %s, expected: %s, got: %s', params.match.json, value, result);
-
-              if (result !== value) {
-                ee.emit('match', false, {
-                  expected: value,
-                  got: result,
-                  request: requestParams
-                });
-                if (params.match.strict) {
-                  return callback(null, context);
-                }
-              } else {
-                ee.emit('match', true);
-              }
-            }
-
-            if (params.capture) {
-              let capturedVal = jsonpath.eval(r, params.capture.json)[0];
-              context.vars[params.capture.as] = capturedVal;
-
-              debug('capture: %s = %s', params.capture.as, capturedVal);
-
-              if (params.capture.transform) {
-                let transformedVal = engineUtil.evil(
-                  context.vars,
-                  params.capture.transform);
-                context.vars[params.capture.as] = transformedVal;
-                debug('transform: %s = %s',
-                      params.capture.as, context.vars[params.capture.as]);
-              }
-            }
-
-            context.vars.$ = r;
-            context._successCount++;
-            context._pendingRequests--;
-            return callback(null, context);
-          });
+          parser = parseJSON;
+          extractor = extractJSONPath;
         } else if (isXML(res)) {
-          parseXML(res.body, function(err2, doc) {
-            if (err2) {
-              let errCode = err.code || err.message;
-              ee.emit('error', errCode);
-              debug(err);
-              // this aborts the scenario
-              return callback(err, context);
-            }
-
-            if (params.match) {
-              let result = doc.get(params.match.xpath).text();
-              let value = template(params.match.value, context);
-              debug('match: %s, expected: %s, got: %s', params.match.xpath, value, result);
-              if (result !== value) {
-                ee.emit('match', false, {
-                  expected: value,
-                  got: result,
-                  request: requestParams
-                });
-                if (params.match.strict) {
-                  return callback(null, context);
-                }
-              } else {
-                ee.emit('match', true);
-              }
-            }
-            if (params.capture) {
-              let capturedVal = doc.get(params.capture.xpath).text();
-              context.vars[params.capture.as] = capturedVal;
-              debug('capture: %s = %s', params.capture.as, capturedVal);
-              if (params.capture.transform) {
-                let transformedVal = engineUtil.evil(
-                  context.vars,
-                  params.capture.transform);
-                context.vars[params.capture.as] = transformedVal;
-                debug('transform: %s = %s',
-                      params.capture.as, context.vars[params.capture.as]);
-              }
-            }
-
-            context.vars.$ = body; // inconsistency - string here, json object when json
-            context._successCount++;
-            context._pendingRequests--;
-            return callback(null, context);
-          });
+          parser = parseXML;
+          extractor = extractXPath;
+        } else if ((params.capture && params.capture.json) || (params.match && params.match.json)) {
+          // TODO: We might want to issue some kind of a warning here
+          parser = parseJSON;
+          extractor = extractJSONPath;
+        } else if ((params.capture && params.capture.xpath) || (params.match && params.match.xpath)) {
+          // TODO: As above
+          parser = parseXML;
+          extractor = extractXPath;
         } else {
-          // FIXME: We are trying to match on something that we cannot parse.
+          // We really don't know what to do here.
+          parser = parseJSON;
+          extractor = extractJSONPath;
+        }
+
+        parser(res.body, function(err2, doc) {
+          if (err2) {
+            return callback(err2, null);
+          }
+
+          if (params.match) {
+            let expr = params.match.json || params.match.xpath;
+            let result = extractor(doc, expr);
+            let expected = template(params.match.value, context);
+            debug('match: %s, expected: %s, got: %s', expr, expected, result);
+            if (result !== expected) {
+              ee.emit('match', false, {
+                expected: expected,
+                got: result,
+                request: requestParams
+              });
+              if (params.match.strict) {
+                // it's not an error but we finish the scenario
+                return callback(null, context);
+              }
+            } else {
+              ee.emit('match', true);
+            }
+          }
+
+          if (params.capture) {
+            let expr = params.capture.json || params.capture.xpath;
+            let result = extractor(doc, expr);
+            context.vars[params.capture.as] = result;
+            debug('capture: %s = %s', params.capture.as, result);
+
+            if (params.capture.transform) {
+              let result2 = engineUtil.evil(
+                context.vars,
+                params.capture.transform);
+              context.vars[params.capture.as] = result2;
+              debug('transform: %s = %s', params.capture.as, context.vars[params.capture.as]);
+            }
+          }
+
+          debug('context.vars.$ = %j', doc);
+          context.vars.$ = doc;
           context._successCount++;
           context._pendingRequests--;
           return callback(null, context);
-        }
+        });
       } else {
+        context.vars.$ = res.body;
         context._successCount++;
         context._pendingRequests--;
         return callback(null, context);
@@ -331,4 +298,16 @@ function parseXML(body, callback) {
   } catch(err) {
     return callback(err, null);
   }
+}
+
+// doc is a JSON object
+function extractJSONPath(doc, expr) {
+  let result = jsonpath.eval(doc, expr)[0];
+  return result;
+}
+
+// doc is an libxmljs document object
+function extractXPath(doc, expr) {
+  let result = doc.get(expr).text();
+  return result;
 }

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -65,6 +65,9 @@ function template(o, context) {
       }
     });
   } else {
+    if (!/{{/.test(o)) {
+      return o;
+    }
     const funcCallRegex = /{{\s*(\$[A-Za-z0-9_]+\s*\(\s*.*\s*\))\s*}}/;
     let match = o.match(funcCallRegex);
     if (match) {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -103,6 +103,7 @@ function runner(script, payload, options) {
         engine.__name = engineName;
         return engine;
       } catch (e) {
+        console.log(e);
         console.log(
           'WARNING: engine %s specified but module %s could not be loaded',
           engineName,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "esprima": "2.5.0",
     "hogan.js": "^3.0.2",
     "jsck": "0.2.5",
+    "libxmljs": "0.17.1",
     "lodash": "3.10.0",
     "measured": "1.1.0",
     "request": "2.58.0",

--- a/test/index.js
+++ b/test/index.js
@@ -2,10 +2,10 @@ require('./unit/index');
 require('./test_multiple_payloads');
 require('./test_misc');
 require('./test_loop');
+require('./test_capture');
+require('./test_arrivals');
 
 //require('./test_worker_http');
 //require('./test_environments.js');
-//require('./test_capture');
-//require('./test_arrivals');
 //require('./test_think');
 //require('./test_tls');

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-node test/targets/simple.js &
+SILENT=true node test/targets/simple.js &
 simple_pid=$!
 node test/targets/simple_ws.js &
 ws_pid=$!

--- a/test/scripts/captures.json
+++ b/test/scripts/captures.json
@@ -28,12 +28,12 @@
         },
         {"get":
           {
-            "url": "/pets/{{ id }}",
+            "url": "/pets/{{ $.id }}",
             "match": {"json": "$.name", "value": "{{ name }}"}
           }
         },
         {"get": {
-          "url": "/pets/{{ $.id }}",
+          "url": "/pets/{{ id }}",
           "match": {"json": "$.name", "value": "{{ name }}"}
         }}
       ]

--- a/test/scripts/captures.json
+++ b/test/scripts/captures.json
@@ -2,7 +2,7 @@
   "config": {
       "target": "http://127.0.0.1:3003",
       "phases": [
-        { "duration": 30, "arrivalRate": 1 }
+        { "duration": 10, "arrivalRate": 1 }
       ],
       "payload": {
         "fields": ["species", "name"]
@@ -13,7 +13,7 @@
   },
   "scenarios": [
     {
-      "name": "Create a pet and verify it's been created.",
+      "name": "Create a pet and verify it's been created (JSON).",
       "flow": [
         {"post":
           {
@@ -28,10 +28,14 @@
         },
         {"get":
           {
-            "url": "/pets/{{ $.id }}",
+            "url": "/pets/{{ id }}",
             "match": {"json": "$.name", "value": "{{ name }}"}
           }
-        }
+        },
+        {"get": {
+          "url": "/pets/{{ $.id }}",
+          "match": {"json": "$.name", "value": "{{ name }}"}
+        }}
       ]
     }
   ]

--- a/test/scripts/captures2.json
+++ b/test/scripts/captures2.json
@@ -1,0 +1,40 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        { "duration": 10, "arrivalRate": 1 }
+      ],
+      "payload": {
+        "fields": ["species", "name"]
+      },
+      "ensure": {
+        "p95": 300
+      }
+  },
+  "scenarios": [
+    {
+      "name": "Test XML capture",
+      "flow": [
+        {"get":
+          {
+            "url": "/journeys",
+            "capture": {
+              "xpath": "(//Journey)[1]/JourneyId/text()",
+              "transform": "this.JourneyId.toUpperCase()",
+              "as": "JourneyId"
+            }
+          }
+        },
+        {"get":
+          {
+            "url": "/journey/{{ JourneyId }}",
+            "match": {
+              "xpath": "(//Journey/JourneyPrice)[1]/text()",
+              "value": "199"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/targets/simple.js
+++ b/test/targets/simple.js
@@ -71,6 +71,19 @@ server.route({
   handler: postIndex
 });
 
+server.route(
+  {
+    method: 'GET',
+    path: '/journeys',
+    handler: getJourneys
+  });
+
+server.route({
+    method: 'GET',
+    path: '/journey/{id}',
+    handler: getJourney
+  });
+
 server.state('testCookie', {
   ttl: null,
   isSecure: false,
@@ -121,7 +134,7 @@ function postIndex(req, reply) {
 }
 
 function create(req, reply) {
-  var id = uuid.v4().split('-')[0];
+  var id = uuid.v4();//.split('-')[0];
   DB[id] = req.payload;
   DB[id].id = id;
   REQUEST_COUNT++;
@@ -131,9 +144,13 @@ function create(req, reply) {
 function read(req, reply) {
   REQUEST_COUNT++;
   var result = DB[req.params.id];
-  console.log(typeof result);
-  console.log(result);
-  return reply(result).code(200);
+  //console.log(typeof result);
+  //console.log(result);
+  if (result) {
+    return reply(result).code(200);
+  } else {
+    return reply().code(404);
+  }
 }
 
 function stats(req, reply) {
@@ -164,4 +181,56 @@ function expectsCookie(req, reply) {
     }
   }
   reply('ok');
+}
+
+function getJourneys(req, reply) {
+  var response = `
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:tns1="http://" xmlns:tns="http://">
+  <soap:Header></soap:Header>
+  <soap:Body>
+    <tns1:GetJourneys xmlns:tns1="http://">
+        <Journey>
+            <JourneyId>1</JourneyId>
+            <JourneyFromCode>781</JourneyFromCode>
+            <JourneyToCode>871</JourneyToCode>
+        </Journey>
+        <Journey>
+            <JourneyId>2</JourneyId>
+            <JourneyFromCode>781</JourneyFromCode>
+            <JourneyToCode>915</JourneyToCode>
+        </Journey>
+        <Journey>
+            <JourneyId>3</JourneyId>
+            <JourneyFromCode>781</JourneyFromCode>
+            <JourneyToCode>641</JourneyToCode>
+        </Journey>
+    </tns1:GetJourneys>
+  </soap:Body>
+</soap:Envelope>`;
+  return reply(response)
+    .type('application/xml');
+}
+
+function getJourney(req, reply) {
+  console.log(req.params.id);
+  if (req.params.id === '1') {
+    let response = `
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:tns1="http://" xmlns:tns="http://">
+  <soap:Header></soap:Header>
+  <soap:Body>
+    <tns1:GetJourney xmlns:tns1="http://">
+        <Journey>
+            <JourneyId>1</JourneyId>
+            <JourneyFromCode>781</JourneyFromCode>
+            <JourneyToCode>871</JourneyToCode>
+            <JourneyAvailability>5</JourneyAvailability>
+            <JourneyPrice>199</JourneyPrice>
+        </Journey>
+    </tns1:GetJourney>
+  </soap:Body>
+</soap:Envelope>`;
+    return reply(response).type('application/xml');
+  }
+
+  return reply('').code(404);
 }

--- a/test/targets/simple.js
+++ b/test/targets/simple.js
@@ -95,16 +95,19 @@ server.state('testCookie', {
 
 var DB = {};
 
+let reporters = [];
+if (!process.env.SILENT) {
+  reporters.push({
+    reporter: require('good-console'),
+    events: {error: '*', log: '*', response: '*'}
+  });
+}
+
 server.register({
   register: require('good'),
   options: {
     opsInterval: 1000,
-    reporters: [
-      {
-        reporter: require('good-console'),
-        events: {error: '*', log: '*', response: '*'}
-      }
-    ]
+    reporters: reporters
   }
 }, function(err) {
   if (err) {

--- a/test/test_arrivals.js
+++ b/test/test_arrivals.js
@@ -16,7 +16,6 @@ test('arrival phases', function(t) {
   });
 
   ee.on('done', function(stats) {
-    console.log('%j', stats);
     t.end();
   });
   ee.run();

--- a/test/test_capture.js
+++ b/test/test_capture.js
@@ -19,9 +19,15 @@ test('Capture - JSON', (t) => {
     let ee = runner(script, parsedData, {});
 
     ee.on('done', function(stats) {
-      t.assert(stats.aggregate.codes[201] * 2 ===
-               stats.aggregate.codes[200] + stats.aggregate.codes[404],
-               'There should be a 200 and a 400 for every 201');
+      let c200 = stats.aggregate.codes[200];
+      let c201 = stats.aggregate.codes[201];
+      let c404 = stats.aggregate.codes[404];
+      let cond = c201 * 2 === c200 + c404;
+      t.assert(cond,
+               'There should be a 200 and a 404 for every 201');
+      if (!cond) {
+        console.log('200: %s; 201: %s; 404: %s', c200, c201, c404);
+      }
       t.end();
     });
 

--- a/test/test_capture.js
+++ b/test/test_capture.js
@@ -1,14 +1,51 @@
 'use strict';
 
-var test = require('tape');
-var runner = require('../lib/runner').runner;
-var l = require('lodash');
+const test = require('tape');
+const runner = require('../lib/runner').runner;
+const L = require('lodash');
+const csv = require('csv-parse');
+const fs = require('fs');
+const path = require('path');
 
-test('Capture', function(t) {
-  var script = require('./scripts/captures.json');
-  var ee = runner(script);
-  ee.on('done', function(stats) {
-    t.end();
+test('Capture - JSON', (t) => {
+  const fn = './scripts/captures.json';
+  const script = require(fn);
+  const data = fs.readFileSync(path.join(__dirname, 'pets.csv'));
+  csv(data, function(err, parsedData) {
+    if (err) {
+      t.fail(err);
+    }
+
+    let ee = runner(script, parsedData, {});
+
+    ee.on('done', function(stats) {
+      t.assert(stats.aggregate.codes[201] * 2 ===
+               stats.aggregate.codes[200] + stats.aggregate.codes[404],
+               'There should be a 200 and a 400 for every 201');
+      t.end();
+    });
+
+    ee.run();
   });
-  ee.run();
+});
+
+test('Capture - XML', (t) => {
+  const fn = './scripts/captures2.json';
+  const script = require(fn);
+  const data = fs.readFileSync(path.join(__dirname, 'pets.csv'));
+  csv(data, function(err, parsedData) {
+    if (err) {
+      t.fail(err);
+    }
+
+    let ee = runner(script, parsedData, {});
+
+    ee.on('done', function(stats) {
+      t.assert(stats.aggregate.codes[200] > 0, 'Should have a few 200s');
+      t.assert(stats.aggregate.codes[404] === undefined, 'Should have no 404s');
+      t.end();
+    });
+
+    ee.run();
+  });
 });


### PR DESCRIPTION
This PR adds XML/XPath support to the HTTP engine. XML responses can now be captures and matched with XPath expressions.

The PR also includes minor refactoring of the test suite.