### PR TITLE
Capture values from arrays randomly, rather than always the first

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -337,8 +337,12 @@ function dummyParser(body, callback) {
 
 // doc is a JSON object
 function extractJSONPath(doc, expr) {
-  let result = jsonpath.eval(doc, expr)[0];
-  return result;
+  let results = jsonpath.eval(doc, expr);
+  if (results.length > 1) {
+    return results[randomInt(0, results.length - 1)];
+  } else {
+    return results[0];
+  }
 }
 
 // doc is an libxmljs document object
@@ -366,4 +370,8 @@ function extractRegExp(doc, expr) {
 
 function dummyExtractor() {
   return '';
+}
+
+function randomInt (low, high) {
+  return Math.floor(Math.random() * (high - low + 1) + low);
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "MPL-2.0",
   "dependencies": {
-    "JSONPath": "0.10.0",
+    "JSONPath": "0.11.2",
     "arrivals": "latest",
     "async": "1.5.2",
     "debug": "2.2.0",

--- a/test/scripts/captures_array_random.json
+++ b/test/scripts/captures_array_random.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        { "duration": 10, "arrivalRate": 1 }
+      ],
+      "ensure": {
+        "p95": 300
+      }
+  },
+  "scenarios": [
+    {
+      "name": "Get a random device and update its state.",
+      "flow": [
+        {
+          "get":  {
+            "url": "/devices",
+            "capture": {
+              "json": "$.[?(@parentProperty !== 'location' && @parentProperty !== 'group' && @property === 'id')]",
+              "as": "id"
+            }
+          },
+          "put": {
+            "url": "/devices/{{ id }}",
+            "json": {"power": true}
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/targets/simple.js
+++ b/test/targets/simple.js
@@ -104,6 +104,18 @@ server.route({
     handler: getJourney
   });
 
+server.route({
+  method: 'GET',
+  path: '/devices',
+  handler: getDevices
+});
+
+server.route({
+  method: 'PUT',
+  path: '/devices/{id}',
+  handler: putDevice
+});
+
 server.state('testCookie', {
   ttl: null,
   isSecure: false,
@@ -276,4 +288,51 @@ function getJourney(req, reply) {
   }
 
   return reply('').code(404);
+}
+
+function getDevices(req, reply) {
+  var response = `
+[
+  {
+    "id": "4dcb754442b1285785b81833c77f4a46",
+    "label": "Lamp 1",
+    "power": true,
+    "group": {
+      "id": "1c8de82b81f445e7cfaafae49b259c71",
+      "name": "Room"
+    },
+    "location": {
+      "id": "1d6fe8ef0fde4c6d77b0012dc736662c",
+      "name": "Home"
+    }
+  },
+  {
+    "id": "e87c45241a484a3db9730ae4b98678d4",
+    "label": "Lamp 2",
+    "power": false,
+    "group": {
+      "id": "1c8de82b81f445e7cfaafae49b259c71",
+      "name": "Room"
+    },
+    "location": {
+      "id": "1d6fe8ef0fde4c6d77b0012dc736662c",
+      "name": "Home"
+    }
+  }
+]
+`;
+  return reply(response)
+    .type('application/json')
+    .code(200);
+}
+
+function putDevice(req, reply) {
+  if (req.params.id === "4dcb754442b1285785b81833c77f4a46" || req.params.id === "e87c45241a484a3db9730ae4b98678d4") {
+    return reply('{"status": "ok"}')
+      .type('application/json')
+      .code(200);
+  } else {
+    return reply('')
+      .code(404);
+  }
 }

--- a/test/test_capture.js
+++ b/test/test_capture.js
@@ -56,6 +56,20 @@ test('Capture - XML', (t) => {
   });
 });
 
+test('Capture - Random value from array', (t) => {
+  const fn = './scripts/captures_array_random.json';
+  const script = require(fn);
+  let ee = runner(script);
+
+  ee.on('done', (stats) => {
+    t.assert(stats.aggregate.codes[200] > 0, 'Should have a few 200s');
+    t.assert(stats.aggregate.codes[404] === undefined, 'Should have no 404s');
+    t.end();
+  });
+
+  ee.run();
+});
+
 test('Capture - RegExp', (t) => {
   const fn = './scripts/captures-regexp.json';
   const script = require(fn);


### PR DESCRIPTION
Thanks for creating Artillery.

We're using this tool at @LIFX to perform load testing on our HTTP API. When pulling values out of the response body using JSONPath we noticed that it always pulled out the first value. This patch changes the behaviour so that it will randomly pull out a value, rather than the first. This means load is better distributed across multiple resources. In our case, these resources map to physical devices.

We've also bumped the JSONPath version to take advantage of more complex paths such as `@parentProperty` and `@property`. 

I've put together an example to demonstrate the behaviour. Given the following response body for `GET /devices`:

``` json
[
  {
    "id": "4dcb754442b1285785b81833c77f4a46",
    "label": "Lamp 1",
    "power": true,
    "group": {
      "id": "1c8de82b81f445e7cfaafae49b259c71",
      "name": "Room"
    },
    "location": {
      "id": "1d6fe8ef0fde4c6d77b0012dc736662c",
      "name": "Home"
    }
  },
  {
    "id": "e87c45241a484a3db9730ae4b98678d4",
    "label": "Lamp 2",
    "power": false,
    "group": {
      "id": "1c8de82b81f445e7cfaafae49b259c71",
      "name": "Room"
    },
    "location": {
      "id": "1d6fe8ef0fde4c6d77b0012dc736662c",
      "name": "Home"
    }
  }
]
```

And the following scenario which gets the list of devices and then updates it's state:

``` json
  "scenarios": [
    {
      "name": "Get a random device and update its state.",
      "flow": [
        {
          "get":  {
            "url": "/devices",
            "capture": {
              "json": "$.[?(@parentProperty !== 'location' && @parentProperty !== 'group' && @property === 'id')]",
              "as": "id"
            }
          },
          "put": {
            "url": "/devices/{{ id }}",
            "json": {"power": "{{ power }}"}
          }
        }
      ]
    }
  ]
```

The `{{ id }}` variable will be either `"e87c45241a484a3db9730ae4b98678d4"` or `"e87c45241a484a3db9730ae4b98678d4"`. Before the patch it would always be `"e87c45241a484a3db9730ae4b98678d4"`. Now when we run the scenario we can be confident that we are distributing load across a number of distinct resources. "Random" is good enough for our purposes, but you could potentially change it's weighting in the future.

I hope you think this patch is useful. All feedback welcome.