### PR TITLE
libxmljs dependency is now optional

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -17,7 +17,12 @@ const template = engineUtil.template;
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
-const xml = require('libxmljs');
+
+let xmlCapture = null;
+try {
+  xmlCapture = require('artillery-xml-capture');
+} catch (e) {
+}
 
 module.exports = HttpEngine;
 
@@ -125,9 +130,9 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
         if ((params.capture && params.capture.json) || (params.match && params.match.json)) {
           parser = parseJSON;
           extractor = extractJSONPath;
-        } else if ((params.capture && params.capture.xpath) || (params.match && params.match.xpath)) {
-          parser = parseXML;
-          extractor = extractXPath;
+        } else if (xmlCapture && (params.capture && params.capture.xpath) || (params.match && params.match.xpath)) {
+          parser = xmlCapture.parseXML;
+          extractor = xmlCapture.extractXPath;
         } else if ((params.capture && params.capture.regexp) || (params.match && params.match.regexp)) {
           parser = dummyParser;
           extractor = extractRegExp;
@@ -135,9 +140,9 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
           if (isJSON(res)) {
             parser = parseJSON;
             extractor = extractJSONPath;
-          } else if (isXML(res)) {
-            parser = parseXML;
-            extractor = extractXPath;
+          } else if (xmlCapture && isXML(res)) {
+            parser = xmlCapture.parseXML;
+            extractor = xmlCapture.extractXPath;
           } else {
             // We really don't know what to do here.
             parser = dummyParser;
@@ -319,18 +324,6 @@ function parseJSON(body, callback) {
   }
 }
 
-/*
- * Wrap XML parser in a callback
- */
-function parseXML(body, callback) {
-  try {
-    let doc = xml.parseXml(body);
-    return callback(null, doc);
-  } catch(err) {
-    return callback(err, null);
-  }
-}
-
 function dummyParser(body, callback) {
   return callback(null, body);
 }
@@ -343,12 +336,6 @@ function extractJSONPath(doc, expr) {
   } else {
     return results[0];
   }
-}
-
-// doc is an libxmljs document object
-function extractXPath(doc, expr) {
-  let result = doc.get(expr).text();
-  return result;
 }
 
 // doc is a string or an object (body parsed by Request when headers indicate JSON)

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   },
   "pre-commit": [
     "is_linted"
-  ]
+  ],
+  "optionalDependencies": {
+    "artillery-xml-capture": "^1.0.0"
+  }
 }

--- a/test/test_capture.js
+++ b/test/test_capture.js
@@ -7,6 +7,13 @@ const csv = require('csv-parse');
 const fs = require('fs');
 const path = require('path');
 
+let xmlCapture = null;
+try {
+  xmlCapture = require('artillery-xml-capture');
+} catch (e) {
+
+}
+
 test('Capture - JSON', (t) => {
   const fn = './scripts/captures.json';
   const script = require(fn);
@@ -36,6 +43,12 @@ test('Capture - JSON', (t) => {
 });
 
 test('Capture - XML', (t) => {
+  if (!xmlCapture) {
+    console.log('artillery-xml-capture does not seem to be installed, skipping XML capture test.');
+    t.assert(true);
+    return t.end();
+  }
+
   const fn = './scripts/captures2.json';
   const script = require(fn);
   const data = fs.readFileSync(path.join(__dirname, 'pets.csv'));


### PR DESCRIPTION
`libxmljs` has been causing lots of installation problems (especially on Windows) - these changes make it an optional dependency.