### PR TITLE
Remove dependency on artillery-xml-capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,5 @@
   },
   "pre-commit": [
     "is_linted"
-  ],
-  "optionalDependencies": {
-    "artillery-xml-capture": "^1.0.0"
-  }
+  ]
 }


### PR DESCRIPTION
libxmljs breaks in too many environments and for now the support
for XPath capture will need to be installed separately