### PR TITLE
Allow for capture groups in regexp

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -181,8 +181,13 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
           }
 
           if (params.capture) {
+            let result;
             let expr = params.capture.json || params.capture.xpath || params.capture.regexp;
-            let result = extractor(doc, expr);
+            if(params.capture.regexp && params.capture.group) {
+              result = extractor(doc, expr, params.capture.group);
+            } else {
+              result = extractor(doc, expr);
+            }
             context.vars[params.capture.as] = result;
             debug('capture: %s = %s', params.capture.as, result);
 
@@ -344,7 +349,7 @@ function extractJSONPath(doc, expr) {
 }
 
 // doc is a string or an object (body parsed by Request when headers indicate JSON)
-function extractRegExp(doc, expr) {
+function extractRegExp(doc, expr, group) {
   let str;
   if (typeof doc === 'string') {
     str = doc;
@@ -353,7 +358,9 @@ function extractRegExp(doc, expr) {
   }
   let rx = new RegExp(expr);
   let match = rx.exec(str);
-  if (match[0]) {
+  if(group && match[group]) {
+    return match[group];
+  } else if (match[0]) {
     return match[0];
   } else {
     return '';

--- a/test/scripts/captures_regexp_group.json
+++ b/test/scripts/captures_regexp_group.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        { "duration": 10, "arrivalRate": 1 }
+      ],
+      "ensure": {
+        "p95": 300
+      }
+  },
+  "scenarios": [
+    {
+      "name": "Get an input value.",
+      "flow": [
+        {
+          "get":  {
+            "url": "/devices",
+            "capture": {
+              "regexp": "<input name=\"some-name\" type=\"text\" value=\"(.*?)\" ",
+              "as": "inputvalue",
+              "group" : 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Enable users to specify a particular result from a regexp when that expression returns multiple matches