### PR TITLE
The socket.io engine now delegates http

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -9,10 +9,13 @@ const _ = require('lodash');
 const io = require('socket.io-client');
 const debug = require('debug')('socketio');
 const engineUtil = require('./engine_util');
+const engineHttp = require('./engine_http');
+const template = engineUtil.template;
 module.exports = SocketIoEngine;
 
 function SocketIoEngine(config) {
   this.config = config;
+  this.httpDelegate = new engineHttp(config);
 }
 
 function markEndTime(ee, context, startedAt) {
@@ -20,6 +23,7 @@ function markEndTime(ee, context, startedAt) {
   let delta = (endedAt[0] * 1e9) + endedAt[1];
   ee.emit('response', delta, 0, context._uid);
 }
+
 function isResponseRequired(spec) {
   return (spec.emit && spec.emit.response && spec.emit.response.channel);
 }
@@ -27,7 +31,7 @@ function isResponseRequired(spec) {
 function processResponse(ee, data, expectedData) {
   let err = null;
 
-  if (!data || (expectedData && (data !== expectedData))) {
+  if (expectedData && (data !== expectedData)) {
     debug(data);
     err = 'data is not valid';
     ee.emit('error', err);
@@ -41,6 +45,9 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
 
   if (requestSpec.loop) {
     let steps = _.map(requestSpec.loop, function(rs) {
+      if (!rs.emit) {
+        return self.httpDelegate.step(rs, ee);
+      }
       return self.step(rs, ee);
     });
 
@@ -48,6 +55,14 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
   }
 
   let f = function(context, callback) {
+    // Only process emit requests; delegate the rest to the HTTP engine
+    if (!requestSpec.emit) {
+      let delegateFunc = self.httpDelegate.step(requestSpec, ee);
+      if (!context.vars) {
+        context.vars = {};
+      }
+      return delegateFunc(context, callback);
+    }
     ee.emit('request');
     let startedAt = process.hrtime();
 
@@ -55,23 +70,31 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
       ee.emit('error', 'invalid arguments');
     }
 
+    let outgoing = {
+      channel: template(requestSpec.emit.channel, context),
+      data: template(requestSpec.emit.data, context)
+    };
+
     if (isResponseRequired(requestSpec)) {
+      let response = {
+        channel: template(requestSpec.emit.response.channel, context),
+        data: template(requestSpec.emit.response.data, context)
+      };
       // Listen for the socket.io response on the specified channel
-      let responseChannel = requestSpec.emit.response.channel;
-      context.socketio.on(responseChannel, function receive(data) {
-        let err = processResponse(ee, data, requestSpec.emit.response.data);
+      context.socketio.on(response.channel, function receive(data) {
+        let err = processResponse(ee, data, response.data);
         if (!err) {
           markEndTime(ee, context, startedAt);
         }
         // Stop listening on the response channel
-        context.socketio.off(responseChannel);
+        context.socketio.off(response.channel);
         return callback(err, context);
       });
       // Send the data on the specified socket.io channel
-      context.socketio.emit(requestSpec.emit.channel, requestSpec.emit.data);
+      context.socketio.emit(outgoing.channel, outgoing.data);
     } else {
       // No return data is expected, so emit without a listener
-      context.socketio.emit(requestSpec.emit.channel, requestSpec.emit.data);
+      context.socketio.emit(outgoing.channel, outgoing.data);
       markEndTime(ee, context, startedAt);
       return callback(null, context);
     }

--- a/test/scripts/express_socketio.json
+++ b/test/scripts/express_socketio.json
@@ -2,7 +2,7 @@
   "config": {
       "target": "http://127.0.0.1:9092",
       "phases": [
-        {"duration": 10, "arrivalRate": 1}
+        {"duration": 20, "arrivalRate": 1}
       ]
   },
   "scenarios": [
@@ -14,12 +14,17 @@
     {
       "engine": "socketio",
       "flow": [
+        {"emit": { "channel": "echo", "data": "first one" }},
+        {"get": { "url": "/test-get", "capture": { "json": "$.key", "as": "key" } }},
+        {"post": { "url": "/test-post?param1=value1&param2={{key}}" }},
+        {"put": { "url": "/test-put?param1=value1&param2={{key}}" }},
+        {"delete": { "url": "/test-delete?param1=value1&param2={{key}}" }},
+        {"emit": { "channel": "echo", "data": "{{key}}", "response": { "channel": "echoed", "data": "{{key}}"} }},
         {"emit": { "channel": "echo", "data": "hello", "response": { "channel": "echoed", "data": "hello"} }},
         {"emit": { "channel": "echo", "data": "world", "response": { "channel": "echoed", "data": "world"} }},
         {"think": 1},
         {"emit": { "channel": "echo", "data": "do not care about the response" }},
         {"emit": { "channel": "echo", "data": "still do not care about the response" }},
-        {"emit": { "channel": "echo", "data": "{\"key\":\"value\"}", "response": { "channel": "echoed", "data": "{\"key\":\"value\"}"} }},
         {"think": 1}
       ]
     }

--- a/test/targets/express_socketio.js
+++ b/test/targets/express_socketio.js
@@ -1,5 +1,9 @@
 var app = require('express')();
-app.get('/test', handler);
+app.get('/test-get', handler);
+app.post('/test-post', handler);
+app.put('/test-put', handler);
+app.delete('/test-delete', handler);
+
 var http = require('http').createServer(app);
 var io = require('socket.io')(http);
 var PORT = 9092;


### PR DESCRIPTION
The socket.io engine now delegates all requests except emit to the http engine.  Also fixed socket.io’s processing of captured parameters.