### PR TITLE
HTTP engine: add ability to capture response headers

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -141,6 +141,9 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
         } else if ((params.capture && params.capture.regexp) || (params.match && params.match.regexp)) {
           parser = dummyParser;
           extractor = extractRegExp;
+        } else if ((params.capture && params.capture.header) || (params.match && params.match.header)) {
+          parser = dummyParser;
+          extractor = extractHeader;
         } else {
           if (isJSON(res)) {
             parser = parseJSON;
@@ -155,7 +158,14 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
           }
         }
 
-        parser(res.body, function(err2, doc) {
+        // are we looking at body or headers:
+        var content = res.body;
+        if ((params.capture && params.capture.header) ||
+            (params.match && params.match.header)) {
+          content = res.headers;
+        }
+
+        parser(content, function(err2, doc) {
           if (err2) {
             return callback(err2, null);
           }
@@ -182,8 +192,11 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
 
           if (params.capture) {
             let result;
-            let expr = params.capture.json || params.capture.xpath || params.capture.regexp;
-            if(params.capture.regexp && params.capture.group) {
+            let expr = (params.capture.json ||
+                        params.capture.xpath ||
+                        params.capture.regexp ||
+                        params.capture.header);
+            if (params.capture.regexp && params.capture.group) {
               result = extractor(doc, expr, params.capture.group);
             } else {
               result = extractor(doc, expr);
@@ -365,6 +378,10 @@ function extractRegExp(doc, expr, group) {
   } else {
     return '';
   }
+}
+
+function extractHeader(headers, headerName) {
+  return headers[headerName];
 }
 
 function dummyExtractor() {

--- a/test/scripts/captures-header.json
+++ b/test/scripts/captures-header.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+    "target": "http://127.0.0.1:3003",
+    "phases": [
+      { "duration": 10, "arrivalRate": 1 }
+    ]
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {"get":
+         {
+           "url": "/header",
+           "capture": { "header": "x-auth", "as": "authToken"}
+         }
+        },
+        {"get":
+         {
+           "url": "/expectsHeader",
+           "headers": {"x-auth": "{{ authToken }}"}
+         }
+        }
+      ]
+    }
+  ]
+}

--- a/test/targets/simple.js
+++ b/test/targets/simple.js
@@ -91,6 +91,26 @@ server.route({
   handler: postIndex
 });
 
+server.route({
+  method: 'GET',
+  path: '/header',
+  handler: function(request, reply) {
+    return reply().header('x-auth', 'secret');
+  }
+});
+
+server.route({
+  method: 'GET',
+  path: '/expectsHeader',
+  handler: function(request, reply) {
+    if (request.headers['x-auth'] && request.headers['x-auth'] === 'secret') {
+      return reply({success: true}).code(200);
+    } else {
+      return reply().code(403);
+    }
+  }
+});
+
 server.route(
   {
     method: 'GET',

--- a/test/test_capture.js
+++ b/test/test_capture.js
@@ -14,6 +14,21 @@ try {
 
 }
 
+test('Capture - headers', (t) => {
+  const fn = './scripts/captures-header.json';
+  const script = require(fn);
+  let ee = runner(script);
+  ee.on('done', function(stats) {
+    // This will fail if header capture isn't working
+    t.assert(!stats.aggregate.codes[403], 'No unauthorized responses');
+    t.assert(stats.aggregate.codes[200] > 0, 'Successful responses');
+    t.end();
+  });
+  ee.run();
+});
+
+
+
 test('Capture - JSON', (t) => {
   const fn = './scripts/captures.json';
   const script = require(fn);


### PR DESCRIPTION
Headers can now be captured with:

```javascript
{"get": {"url": "/url", "capture": { "header": "header-name", "as": "variableName" }}}
```