### PR TITLE
(#99) - per-run stats records

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -31,30 +31,12 @@ module.exports = {
   validate: validate
 };
 
-// Only one runner can execute at a time when used as a library.
-
-let pendingRequests = 0;
-let pendingScenarios = 0;
-
-let compiledScenarios;
-let scenarioEvents;
-let picker;
-
-let Report = {
-  intermediate: [],
-  aggregate: {}
-};
-
-let plugins = [];
-let engines = [];
-
 function validate(script) {
   let validation = schema.validate(script);
   return validation;
 }
 
 function runner(script, payload, options) {
-
   let opts = _.assign({
     periodicStats: script.config.statsInterval || 10,
     mode: script.config.mode || 'uniform'
@@ -93,67 +75,81 @@ function runner(script, payload, options) {
       script.config.environments[opts.environment]);
   }
 
-  compiledScenarios = null;
-  scenarioEvents = null;
-
   let ee = new EventEmitter();
 
   //
   // load engines:
   //
-  engines = _.map(Object.assign({}, Engines, runnableScript.config.engines),
-    function loadEngine(engineConfig, engineName) {
-      let moduleName = 'artillery-engine-' + engineName;
-      try {
-        if (Engines[engineName]) {
-          moduleName = './engine_' + engineName;
+  let runnerEngines = _.map(
+      Object.assign({}, Engines, runnableScript.config.engines),
+      function loadEngine(engineConfig, engineName) {
+        let moduleName = 'artillery-engine-' + engineName;
+        try {
+          if (Engines[engineName]) {
+            moduleName = './engine_' + engineName;
+          }
+          let Engine = require(moduleName);
+          let engine = new Engine(runnableScript.config, ee);
+          engine.__name = engineName;
+          return engine;
+        } catch (e) {
+          console.log(e);
+          console.log(
+              'WARNING: engine %s specified but module %s could not be loaded',
+              engineName,
+              moduleName);
         }
-        let Engine = require(moduleName);
-        let engine = new Engine(runnableScript.config, ee);
-        engine.__name = engineName;
-        return engine;
-      } catch (e) {
-        console.log(e);
-        console.log(
-          'WARNING: engine %s specified but module %s could not be loaded',
-          engineName,
-          moduleName);
       }
-    });
+  );
 
   //
   // load plugins:
   //
-  plugins = _.map(runnableScript.config.plugins,
-    function loadPlugin(pluginConfig, pluginName) {
-      let moduleName = 'artillery-plugin-' + pluginName;
-      try {
-        let Plugin = require(moduleName);
-        let plugin = new Plugin(runnableScript.config, ee);
-        plugin.__name = pluginName;
-        return plugin;
-      } catch (e) {
-        console.log(
-          'WARNING: plugin %s specified but module %s could not be loaded',
-          pluginName,
-          moduleName);
+  let runnerPlugins = _.map(
+      runnableScript.config.plugins,
+      function loadPlugin(pluginConfig, pluginName) {
+        let moduleName = 'artillery-plugin-' + pluginName;
+        try {
+          let Plugin = require(moduleName);
+          let plugin = new Plugin(runnableScript.config, ee);
+          plugin.__name = pluginName;
+          return plugin;
+        } catch (e) {
+          console.log(
+              'WARNING: plugin %s specified but module %s could not be loaded',
+              pluginName,
+              moduleName);
+        }
       }
-    });
+  );
 
   ee.run = function() {
+    let runState = {
+      pendingScenarios: 0,
+      pendingRequests: 0,
+      compiledScenarios: null,
+      scenarioEvents: null,
+      picker: undefined,
+      Report: {
+        intermediate: [],
+        aggregate: {}
+      },
+      plugins: runnerPlugins,
+      engines: runnerEngines
+    };
     debug('run() with: %j', runnableScript);
-    run(runnableScript, ee, opts);
+    run(runnableScript, ee, opts, runState);
   };
   return ee;
 }
 
-function run(script, ee, options) {
+function run(script, ee, options, runState) {
   let intermediate = Stats.create();
   let aggregate = Stats.create();
 
   let phaser = createPhaser(script.config.phases);
   phaser.on('arrival', function() {
-    runScenario(script, intermediate, aggregate);
+    runScenario(script, intermediate, aggregate, runState);
   });
   phaser.on('phaseStarted', function(spec) {
     ee.emit('phaseStarted', spec);
@@ -165,12 +161,12 @@ function run(script, ee, options) {
     debug('All phases launched');
 
     const doneYet = setInterval(function checkIfDone() {
-      if (pendingScenarios === 0) {
-        if (pendingRequests !== 0) {
-          debug('DONE. Pending requests: %s', pendingRequests);
+      if (runState.pendingScenarios === 0) {
+        if (runState.pendingRequests !== 0) {
+          debug('DONE. Pending requests: %s', runState.pendingRequests);
         }
 
-        Report.aggregate = aggregate.report();
+        runState.Report.aggregate = aggregate.report();
         clearInterval(doneYet);
         clearInterval(periodicStatsTimer);
         intermediate.free();
@@ -179,39 +175,39 @@ function run(script, ee, options) {
         //
         // Add plugin reports to the final report
         //
-        _.each(plugins, function(plugin) {
+        _.each(runState.plugins, function(plugin) {
           if (typeof plugin.report === 'function') {
             let report = plugin.report();
             if (report) {
               if (report.length) {
                 _.each(report, function insertIntermediateReport(a) {
                   if (a.timestamp === 'aggregate') {
-                    Report.aggregate[plugin.__name] = a.value;
+                    runState.Report.aggregate[plugin.__name] = a.value;
                   } else {
                     let ir = _.findWhere(
-                      Report.intermediate,
+                      runState.Report.intermediate,
                       {timestamp: a.timestamp});
                     ir[plugin.__name] = a.value;
                   }
                 });
               } else {
-                Report.aggregate[plugin.__name] = report;
+                runState.Report.aggregate[plugin.__name] = report;
               }
             }
           }
         });
 
-        return ee.emit('done', Report);
+        return ee.emit('done', runState.Report);
       } else {
-        debug('Pending requests: %s', pendingRequests);
-        debug('Pending scenarios: %s', pendingScenarios);
+        debug('Pending requests: %s', runState.pendingRequests);
+        debug('Pending scenarios: %s', runState.pendingScenarios);
       }
     }, 500);
   });
 
   const periodicStatsTimer = setInterval(function() {
     const report = intermediate.report();
-    Report.intermediate.push(report);
+    runState.Report.intermediate.push(report);
     intermediate.reset();
     ee.emit('stats', report);
   }, options.periodicStats * 1000);
@@ -219,44 +215,44 @@ function run(script, ee, options) {
   phaser.run();
 }
 
-function runScenario(script, intermediate, aggregate) {
+function runScenario(script, intermediate, aggregate, runState) {
   const start = process.hrtime();
 
   //
   // Compile scenarios if needed
   //
-  if (!compiledScenarios) {
+  if (!runState.compiledScenarios) {
     _.each(script.scenarios, function(scenario) {
       if (!scenario.weight) {
         scenario.weight = 1;
       }
     });
 
-    picker = wl(script.scenarios);
+    runState.picker = wl(script.scenarios);
 
-    scenarioEvents = new EventEmitter();
-    scenarioEvents.on('customStat', function(stat) {
+    runState.scenarioEvents = new EventEmitter();
+    runState.scenarioEvents.on('customStat', function(stat) {
       intermediate.addCustomStat(stat.stat, stat.value);
       aggregate.addCustomStat(stat.stat, stat.value);
     });
-    scenarioEvents.on('started', function() {
-      pendingScenarios++;
+    runState.scenarioEvents.on('started', function() {
+      runState.pendingScenarios++;
     });
-    scenarioEvents.on('error', function(errCode) {
+    runState.scenarioEvents.on('error', function(errCode) {
       intermediate.addError(errCode);
       aggregate.addError(errCode);
     });
-    scenarioEvents.on('request', function() {
+    runState.scenarioEvents.on('request', function() {
       intermediate.newRequest();
       aggregate.newRequest();
 
-      pendingRequests++;
+      runState.pendingRequests++;
     });
-    scenarioEvents.on('match', function() {
+    runState.scenarioEvents.on('match', function() {
       intermediate.addMatch();
       aggregate.addMatch();
     });
-    scenarioEvents.on('response', function(delta, code, uid) {
+    runState.scenarioEvents.on('response', function(delta, code, uid) {
       intermediate.completedRequest();
       intermediate.addLatency(delta);
       intermediate.addCode(code);
@@ -269,30 +265,33 @@ function runScenario(script, intermediate, aggregate) {
       aggregate.addLatency(delta);
       aggregate.addCode(code);
 
-      pendingRequests--;
+      runState.pendingRequests--;
     });
 
-    compiledScenarios = _.map(script.scenarios, function(scenarioSpec) {
-      const name = scenarioSpec.engine || 'http';
-      const engine = engines.find((e) => e.__name === name);
-      let tasks = _.map(scenarioSpec.flow, rs => {
-        if (rs.think) {
-          return engineUtil.createThink(rs);
+    runState.compiledScenarios = _.map(
+        script.scenarios,
+        function(scenarioSpec) {
+          const name = scenarioSpec.engine || 'http';
+          const engine = runState.engines.find((e) => e.__name === name);
+          let tasks = _.map(scenarioSpec.flow, rs => {
+            if (rs.think) {
+              return engineUtil.createThink(rs);
+            }
+            return engine.step(rs, runState.scenarioEvents);
+          });
+          return engine.compile(
+              tasks,
+              scenarioSpec.flow,
+              runState.scenarioEvents
+          );
         }
-        return engine.step(rs, scenarioEvents);
-      });
-      return engine.compile(
-        tasks,
-        scenarioSpec.flow,
-        scenarioEvents
-        );
-    });
+    );
   }
 
   intermediate.newScenario();
   aggregate.newScenario();
 
-  let i = picker()[0];
+  let i = runState.picker()[0];
 
   debug('picking scenario %s (%s) weight = %s',
         i,
@@ -304,8 +303,8 @@ function runScenario(script, intermediate, aggregate) {
   const finish = process.hrtime(start);
   const runScenarioDelta = (finish[0] * 1e9) + finish[1];
   debugPerf('runScenarioDelta: %s', Math.round(runScenarioDelta / 1e6 * 100) / 100);
-  compiledScenarios[i](scenarioContext, function(err, context) {
-    pendingScenarios--;
+  runState.compiledScenarios[i](scenarioContext, function(err, context) {
+    runState.pendingScenarios--;
     if (err) {
       debug(err);
     } else {
@@ -360,11 +359,9 @@ function createContext(script) {
       result.vars[k] = val;
     });
   }
-
   result._uid = uuid.v4();
   return result;
 }
-
 
 //
 // Generator functions for template strings:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artillery-core",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "core load-generating functionality of Artillery",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/shoreditch-ops/artillery-core.git"
-  }
+  },
+  "pre-commit": [
+    "is_linted"
+  ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ require('./test_misc');
 require('./test_loop');
 require('./test_capture');
 require('./test_arrivals');
+require('./test_reuse');
 
 //require('./test_worker_http');
 //require('./test_environments.js');

--- a/test/test_reuse.js
+++ b/test/test_reuse.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var test = require('tape');
+var runner = require('../lib/runner').runner;
+
+test('reuse', function(t) {
+  let script = require('./scripts/hello.json');
+  let ee = runner(script);
+  let first = true;
+  let expected = 0;
+  let weightedFlowLengths = 0;
+  let lastLatency = null;
+  for (let i = 0; i < script.config.phases.length; i++) {
+    let arrivalRate = script.config.phases[0].arrivalRate;
+    let duration = script.config.phases[0].duration;
+    expected += arrivalRate * duration;
+  }
+  for (let i = 0; i < script.scenarios.length; i++) {
+    let flowLength = script.scenarios[i].flow.length;
+    if (script.scenarios[i].weight) {
+      let scenarioWeight = script.scenarios[i].weight;
+      weightedFlowLengths += scenarioWeight * flowLength;
+    } else {
+      weightedFlowLengths += flowLength;
+    }
+  }
+  expected *= weightedFlowLengths;
+  ee.on('done', function(stats) {
+    let total = 0;
+    for (let i = 0; i < stats.intermediate.length; i++) {
+      total += stats.intermediate[i].latencies.length;
+      t.assert(
+          'intermediate should have the same or fewer results',
+          stats.intermediate[i].latencies.length <= expected
+      );
+    }
+    t.assert(
+        'total of intermediates should have the same or fewer results',
+        total <= expected
+    );
+    t.assert(
+        'aggregate should have the expected number of latencies',
+        stats.aggregate.latencies.length === expected
+    );
+    if (first) {
+      let last = stats.aggregate.latencies.length - 1;
+      first = false;
+      lastLatency = stats.aggregate.latencies[last][0];
+      ee.run();
+    } else {
+      t.assert(
+          'first latency of second aggregate should be after ' +
+          'the last latency of the first aggregate',
+          lastLatency <= stats.aggregate.latencies[0][0]
+      );
+      t.end();
+    }
+  });
+  ee.run();
+});


### PR DESCRIPTION
Resolves issue [#99](https://github.com/shoreditch-ops/artillery/issues/99) 
by creating a new results recording object each time that `run` is called 
on any given `runner`.  Consistent with the current logic, the plugins and 
engines are only loaded once per call to the `runner` function.