### PR TITLE
HTTP engine: Add range support and $loopCount variable to `loop`

### DIFF
--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -32,13 +32,19 @@ function createThink(requestSpec) {
   return f;
 }
 
+// "count" can be an integer (negative or positive) or a string defining a range
+// like "1-15"
 function createLoopWithCount(count, steps) {
+  let from = parseLoopCount(count).from;
+  let to = parseLoopCount(count).to;
+
   return function aLoop(context, callback) {
-    let i = 0;
+    let i = from;
     let newContext = context;
+    newContext.vars.$loopCount = i;
     A.whilst(
       function test() {
-        return i < count || count === -1;
+        return i < to || to === -1;
       },
       function repeated(cb) {
         let zero = function(cb2) {
@@ -48,6 +54,7 @@ function createLoopWithCount(count, steps) {
         A.waterfall(steps2, function(err, context2) {
           i++;
           newContext = context2;
+          newContext.vars.$loopCount++;
           return cb(err, context2);
         });
       },
@@ -104,4 +111,30 @@ function evil(sandbox, code) {
   let context = vm.createContext(sandbox);
   let script = new vm.Script(code);
   return script.runInContext(context);
+}
+
+
+function parseLoopCount(countSpec) {
+  let from = 0;
+  let to = 0;
+
+  if (typeof countSpec === 'number') {
+    from = 0;
+    to = countSpec;
+  } else if (typeof countSpec === 'string') {
+    if (isNaN(Number(countSpec))) {
+      if (/\d\-\d/.test(countSpec)) {
+        from = Number(countSpec.split('-')[0]);
+        to = Number(countSpec.split('-')[1]);
+      } else {
+        to = 0;
+      }
+    } else {
+      to = Number(countSpec);
+    }
+  } else {
+    to = 0;
+  }
+
+  return { from: from, to: to };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ require('./test_loop');
 require('./test_capture');
 require('./test_arrivals');
 require('./test_reuse');
+require('./test_loop');
 
 //require('./test_worker_http');
 //require('./test_environments.js');

--- a/test/scripts/loop_range.json
+++ b/test/scripts/loop_range.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+    "target": "http://localhost:3003",
+    "phases": [
+      {"duration": 10, "arrivalRate": 1}
+    ],
+    "statsInterval": 1
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {
+          "loop": [
+            {"get": {"url": "/"}},
+            {"get": {"url": "/loop/{{ $loopCount }}"}}
+          ],
+          "count": "9-12"
+        }
+      ]
+    }
+  ]
+}

--- a/test/targets/simple.js
+++ b/test/targets/simple.js
@@ -136,6 +136,31 @@ server.route({
   handler: putDevice
 });
 
+//
+// Used by loop_range.json test
+//
+server.route([
+  {
+    method: 'GET',
+    path: '/loop/9',
+    handler: ok
+  },
+  {
+    method: 'GET',
+    path: '/loop/10',
+    handler: ok
+  },
+  {
+    method: 'GET',
+    path: '/loop/11',
+    handler: ok
+  }
+]);
+
+function ok(req, reply) {
+  reply('ok');
+}
+
 server.state('testCookie', {
   ttl: null,
   isSecure: false,

--- a/test/test_loop.js
+++ b/test/test_loop.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const runner = require('../lib/runner').runner;
 const L = require('lodash');
 
-test('loop', (t) => {
+test('simple loop', (t) => {
   const script = require('./scripts/loop.json');
 
   let ee = runner(script);
@@ -16,6 +16,31 @@ test('loop', (t) => {
     t.assert(
       requests === expected,
       'Should have ' + expected + ' requests for each completed scenario');
+    t.end();
+  });
+  ee.run();
+});
+
+test('loop with range', (t) => {
+  const script = require('./scripts/loop_range.json');
+
+  let ee = runner(script);
+  ee.on('done', (stats) => {
+    let scenarios = stats.aggregate.scenariosCompleted;
+    let requests = stats.aggregate.requestsCompleted;
+    let expected = scenarios * 3 * 2;
+    let code200 = stats.aggregate.codes[200];
+    let code404 = stats.aggregate.codes[404];
+
+    t.assert(
+      requests === expected,
+      'Should have ' + expected + ' requests for each completed scenario');
+    t.assert(code200 > 0,
+             'There should be a non-zero number of 200s');
+
+    // If $loopCount breaks, we'll see 404s here.
+    t.assert(!code404,
+             'There should be no 404s');
     t.end();
   });
   ee.run();


### PR DESCRIPTION
- Ranges can be specified with `count: "1-5"` now.
- `$loopCount` variable is now available inside loops
  With `count: "9-12"` `$loopCount` would equal (9, 10, 11)