### PR TITLE
Add option to disable redirection

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -34,13 +34,13 @@ function HttpEngine(config) {
   this.config = config;
 }
 
-HttpEngine.prototype.step = function step(requestSpec, ee) {
+HttpEngine.prototype.step = function step(requestSpec, scenarioSpec, ee) {
   let self = this;
   let config = this.config;
 
   if (requestSpec.loop) {
     let steps = _.map(requestSpec.loop, function(rs) {
-      return self.step(rs, ee);
+      return self.step(rs, scenarioSpec, ee);
     });
 
     return engineUtil.createLoopWithCount(requestSpec.count || -1, steps);
@@ -130,8 +130,12 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
       requestParams.agent = context._agent;
     }
 
-    if (params.followRedirect == false) {
-      requestParams.followRedirect = false
+    if (params.noRedirect != undefined) {
+      requestParams.followRedirect = !params.noRedirect
+    } else if (scenarioSpec.noRedirect != undefined) {
+      requestParams.followRedirect = !scenarioSpec.noRedirect
+    } else if (config.noRedirect != undefined) {
+      requestParams.followRedirect = !config.noRedirect
     }
 
     request(requestParams, function requestCallback(err, res, body) {

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -130,6 +130,10 @@ HttpEngine.prototype.step = function step(requestSpec, ee) {
       requestParams.agent = context._agent;
     }
 
+    if (params.followRedirect == false) {
+      requestParams.followRedirect = false
+    }
+
     request(requestParams, function requestCallback(err, res, body) {
       debug('request: %s', JSON.stringify({
 	uri: requestParams.uri,

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -278,7 +278,7 @@ function runScenario(script, intermediate, aggregate, runState) {
             if (rs.think) {
               return engineUtil.createThink(rs);
             }
-            return engine.step(rs, runState.scenarioEvents);
+            return engine.step(rs, scenarioSpec, runState.scenarioEvents);
           });
           return engine.compile(
               tasks,


### PR DESCRIPTION
It's really great if we could avoid following redirection because a benchmark test of your server is independent from the redirected server's response. Honestly speaking, I hope this behavior is the default.