### PR TITLE
update template to compute non-string types depending on context

### DIFF
--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -115,7 +115,19 @@ function template(o, context) {
         return o;
       }
 
-      result = (hogan.compile(o)).render(context.vars);
+      // Create a hogan template to be rendered.
+      // Hogan will render to an HTML escaped string by default.
+      // The monkey patches below allow for non-string data types and override
+      // HTML escaping logic
+      const template = hogan.compile(o)
+
+      template.d = patchFindValue(template.d)
+      template.f = patchFindValue(template.f)
+      template.b = patchedBuffer
+      template.v = patchedValueEscape
+
+      // Use the monkey-patched template to render the context.
+      result = template.render(context.vars);
     }
   }
   return result;
@@ -128,6 +140,44 @@ function evil(sandbox, code) {
   return script.runInContext(context);
 }
 
+// Patch hogan functions that find values to handle the case where undefined
+// would otherwise be coerced to an empty string.
+// The original functions are defined here:
+//   https://github.com/twitter/hogan.js/blob/7e340e9e4dde8faebd1ff34e62abc1c5dd8adb55/lib/template.js#L137
+//   https://github.com/twitter/hogan.js/blob/7e340e9e4dde8faebd1ff34e62abc1c5dd8adb55/lib/template.js#L172
+function patchFindValue(findFn) {
+  return function(key, ctx, partials, returnFound) {
+    const result = findFn.call(this, key, ctx, partials, returnFound)
+    if (result !== '') {
+      return result;
+    }
+    for (let i = ctx.length - 1; i >= 0; i--) {
+      const result = L.get(ctx[i], key)
+      if (result !== undefined) {
+        return result
+      }
+    }
+  }
+}
+
+// Monkey-patch the buffering logic to allow for non-string data types.
+// If the buffer is empty, set it to the incoming value without coercing
+// it to a string. Otherwise, add the incoming value to the buffer and
+// convert it to a string.
+// The original function is defined here:
+//   https://github.com/twitter/hogan.js/blob/7e340e9e4dde8faebd1ff34e62abc1c5dd8adb55/lib/template.js#L218
+function patchedBuffer(s) {
+  this.buf = this.buf
+    ? '' + this.buf + (s != null ? s : '')
+    : s;
+}
+
+// Monkey-patch the value escaping logic to be the identity function.
+// The original function is defined here:
+//   https://github.com/twitter/hogan.js/blob/7e340e9e4dde8faebd1ff34e62abc1c5dd8adb55/lib/template.js#L325
+function patchedValueEscape(x) {
+  return x;
+}
 
 function parseLoopCount(countSpec) {
   let from = 0;

--- a/test/unit/templates.test.js
+++ b/test/unit/templates.test.js
@@ -4,15 +4,9 @@ var test = require('tape');
 var template = require('../../lib/engine_util').template;
 
 // TODO:
-// plain strings
-// string with a {{}}
-// string with multiple {{}}s
 // string with a function
 // string with multiple functions
 // string with a function and a {{}}
-// same but for an object
-
-// variables that aren't defined
 // functions that aren't defined
 
 var emptyContext = { vars: {} };
@@ -23,8 +17,67 @@ test('templating a plain string should return the same string', function(t) {
   t.end();
 });
 
-test.test('variables can be substituted', function(t) {
+test.test('string variables can be substituted', function(t) {
   t.assert(template('hello {{name}}', { vars: { name: 'Hassy'} }) === 'hello Hassy', '');
   t.assert(template('hello {{name}}', emptyContext) === 'hello ', '');
+  t.end();
+});
+
+test.test('strings with multiple variables can be substituted', function(t) {
+  t.assert(template('hello {{nameFirst}} {{nameLast}}', { vars: { nameFirst: 'Neil', nameLast: 'Armstrong'} }) === 'hello Neil Armstrong', '');
+  t.end();
+});
+
+test.test('substituted string variables are not HTML escaped', function(t) {
+  t.equal(template('{{lawFirm}}', { vars: { lawFirm: 'Michelson, Jones & Peterson LLC.'} }), 'Michelson, Jones & Peterson LLC.', '');
+  t.end();
+});
+
+test.test('numeric variables can be substituted', function(t) {
+  t.equal(template('{{int}}', { vars: { int: 5 } }), 5, '');
+  t.end();
+});
+
+test.test('whole objects can be substituted', function(t) {
+  t.deepEqual(template('{{obj}}', { vars: { obj: { nested: 'data' } } }), { nested: 'data' }, '');
+  t.end();
+});
+
+test.test('when concatenated with other strings, null and undefined are substituted as an empty string', function(t) {
+  t.equal(template('hello {{name}}', { vars: { name: null } }), 'hello ', '');
+  t.equal(template('hello {{name}}', { vars: { name: undefined } }), 'hello ', '');
+  t.equal(template('hello {{name}}', { vars: {} }), 'hello ', '');
+  t.end();
+});
+
+test.test('when substituted on their own, null and undefined retain their original values', function(t) {
+  t.equal(template('{{name}}', { vars: { name: null } }), null, '');
+  t.equal(template('{{name}}', { vars: { name: undefined } }), undefined, '');
+  t.equal(template('{{name}}', { vars: {} }), undefined, '');
+  t.end();
+});
+
+test.test('dotted variables can be substituted', function(t) {
+  const context = {
+    vars: {
+      nested: {
+        str: 'someText',
+        int: 5,
+        emptyString: '',
+        explicitNull: null,
+        explicitUndefined: undefined,
+        deeply: {
+          some: 'data'
+        }
+      }
+    }
+  };
+  t.deepEqual(template('{{nested.str}}', context), 'someText', '');
+  t.deepEqual(template('{{nested.int}}', context), 5, '');
+  t.deepEqual(template('{{nested.emptyString}}', context), '', '');
+  t.deepEqual(template('{{nested.explicitNull}}', context), null, '');
+  t.deepEqual(template('{{nested.explicitUndefined}}', context), undefined, '');
+  t.deepEqual(template('{{nested.deeply}}', context), {some: 'data'}, '');
+  t.deepEqual(template('{{nested.implicitUndefined}}', context), undefined, '');
   t.end();
 });


### PR DESCRIPTION
Allows a previously captured non-string value to be included as JSON in the body of a subsequent request. If for example there is a specification:

``` yaml
config:
  target: http://foo.com
scenarios:
  - flow:
    - get:
        url: /a-route
        capture: 
          json: "$"
          as: thing
    - post:
        url: /another-route
        json: "{{thing}}"
```

and the GET to `http://foo.com/a-route` resolves with `{"nested": "data"}`, now `{"nested": "data"}` is posted to  `http://foo.com/another-route` instead of `[object Object]`.

The PR works on account of a pretty gross monkey-patch of [hogan.js](https://github.com/twitter/hogan.js). While it works, it's a total hack and I'd be open to other ways of achieving the same end.

If there are any other questions/concerns regarding this PR, please let me know.

Thanks!
