### PR TITLE
Fix for Issue #80: "stats" event does not get an event for the last set of responses.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -182,9 +182,17 @@ function run(script, ee, options, runState) {
           debug('DONE. Pending requests: %s', runState.pendingRequests);
         }
 
-        runState.Report.aggregate = aggregate.report();
         clearInterval(doneYet);
         clearInterval(periodicStatsTimer);
+
+        runState.Report.aggregate = aggregate.report();
+        const report = intermediate.report();
+
+        report.concurrency = runState.pendingScenarios;
+        report.pendingRequests = runState.pendingRequests;
+        runState.Report.intermediate.push(report);
+        ee.emit('stats', report);
+
         intermediate.free();
         aggregate.free();
 
@@ -224,6 +232,7 @@ function run(script, ee, options, runState) {
   const periodicStatsTimer = setInterval(function() {
     const report = intermediate.report();
     report.concurrency = runState.pendingScenarios;
+    report.pendingRequests = runState.pendingRequests;
     runState.Report.intermediate.push(report);
     intermediate.reset();
     ee.emit('stats', report);


### PR DESCRIPTION
Add additional 'stats' event call to process the balance of the un-reproted responses during 'done' event handling.