### PR TITLE
Simplify runner events

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -200,8 +200,7 @@ function run(script, ee, options, runState) {
     aggregate.push(intermediate.clone());
     intermediate._concurrency = runState.pendingScenarios;
     intermediate._pendingRequests = runState.pendingRequests;
-    const report = intermediate.report();
-    ee.emit('stats', report);
+    ee.emit('stats', intermediate.clone());
     intermediate.reset();
   }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -146,10 +146,6 @@ function runner(script, payload, options) {
       compiledScenarios: null,
       scenarioEvents: null,
       picker: undefined,
-      Report: {
-        intermediate: [],
-        aggregate: {}
-      },
       plugins: runnerPlugins,
       engines: runnerEngines
     };
@@ -161,11 +157,11 @@ function runner(script, payload, options) {
 
 function run(script, ee, options, runState) {
   let intermediate = Stats.create();
-  let aggregate = Stats.create();
+  let aggregate = [];
 
   let phaser = createPhaser(script.config.phases);
   phaser.on('arrival', function() {
-    runScenario(script, intermediate, aggregate, runState);
+    runScenario(script, intermediate, runState);
   });
   phaser.on('phaseStarted', function(spec) {
     ee.emit('phaseStarted', spec);
@@ -185,13 +181,12 @@ function run(script, ee, options, runState) {
         clearInterval(doneYet);
         clearInterval(periodicStatsTimer);
 
-        runState.Report.aggregate = aggregate.report();
         sendStats();
 
         intermediate.free();
-        aggregate.free();
 
-        return ee.emit('done', runState.Report);
+        let aggregateReport = Stats.combine(aggregate).report();
+        return ee.emit('done', aggregateReport);
       } else {
         debug('Pending requests: %s', runState.pendingRequests);
         debug('Pending scenarios: %s', runState.pendingScenarios);
@@ -202,18 +197,18 @@ function run(script, ee, options, runState) {
   const periodicStatsTimer = setInterval(sendStats, options.periodicStats * 1000);
 
   function sendStats() {
+    aggregate.push(intermediate.clone());
+    intermediate._concurrency = runState.pendingScenarios;
+    intermediate._pendingRequests = runState.pendingRequests;
     const report = intermediate.report();
-    report.concurrency = runState.pendingScenarios;
-    report.pendingRequests = runState.pendingRequests;
-    runState.Report.intermediate.push(report);
-    intermediate.reset();
     ee.emit('stats', report);
+    intermediate.reset();
   }
 
   phaser.run();
 }
 
-function runScenario(script, intermediate, aggregate, runState) {
+function runScenario(script, intermediate, runState) {
   const start = process.hrtime();
 
   //
@@ -231,24 +226,20 @@ function runScenario(script, intermediate, aggregate, runState) {
     runState.scenarioEvents = new EventEmitter();
     runState.scenarioEvents.on('customStat', function(stat) {
       intermediate.addCustomStat(stat.stat, stat.value);
-      aggregate.addCustomStat(stat.stat, stat.value);
     });
     runState.scenarioEvents.on('started', function() {
       runState.pendingScenarios++;
     });
     runState.scenarioEvents.on('error', function(errCode) {
       intermediate.addError(errCode);
-      aggregate.addError(errCode);
     });
     runState.scenarioEvents.on('request', function() {
       intermediate.newRequest();
-      aggregate.newRequest();
 
       runState.pendingRequests++;
     });
     runState.scenarioEvents.on('match', function() {
       intermediate.addMatch();
-      aggregate.addMatch();
     });
     runState.scenarioEvents.on('response', function(delta, code, uid) {
       intermediate.completedRequest();
@@ -257,11 +248,6 @@ function runScenario(script, intermediate, aggregate, runState) {
 
       let entry = [Date.now(), uid, delta, code];
       intermediate.addEntry(entry);
-      aggregate.addEntry(entry);
-
-      aggregate.completedRequest();
-      aggregate.addLatency(delta);
-      aggregate.addCode(code);
 
       runState.pendingRequests--;
     });
@@ -277,7 +263,6 @@ function runScenario(script, intermediate, aggregate, runState) {
   }
 
   intermediate.newScenario();
-  aggregate.newScenario();
 
   let i = runState.picker()[0];
 
@@ -299,9 +284,7 @@ function runScenario(script, intermediate, aggregate, runState) {
       const scenarioFinishedAt = process.hrtime(scenarioStartedAt);
       const delta = (scenarioFinishedAt[0] * 1e9) + scenarioFinishedAt[1];
       intermediate.addScenarioLatency(delta);
-      aggregate.addScenarioLatency(delta);
       intermediate.completedScenario();
-      aggregate.completedScenario();
     }
   });
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -186,12 +186,7 @@ function run(script, ee, options, runState) {
         clearInterval(periodicStatsTimer);
 
         runState.Report.aggregate = aggregate.report();
-        const report = intermediate.report();
-
-        report.concurrency = runState.pendingScenarios;
-        report.pendingRequests = runState.pendingRequests;
-        runState.Report.intermediate.push(report);
-        ee.emit('stats', report);
+        sendStats();
 
         intermediate.free();
         aggregate.free();
@@ -229,14 +224,16 @@ function run(script, ee, options, runState) {
     }, 500);
   });
 
-  const periodicStatsTimer = setInterval(function() {
+  const periodicStatsTimer = setInterval(sendStats, options.periodicStats * 1000);
+
+  function sendStats() {
     const report = intermediate.report();
     report.concurrency = runState.pendingScenarios;
     report.pendingRequests = runState.pendingRequests;
     runState.Report.intermediate.push(report);
     intermediate.reset();
     ee.emit('stats', report);
-  }, options.periodicStats * 1000);
+  }
 
   phaser.run();
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -191,31 +191,6 @@ function run(script, ee, options, runState) {
         intermediate.free();
         aggregate.free();
 
-        //
-        // Add plugin reports to the final report
-        //
-        _.each(runState.plugins, function(plugin) {
-          if (typeof plugin.report === 'function') {
-            let report = plugin.report();
-            if (report) {
-              if (report.length) {
-                _.each(report, function insertIntermediateReport(a) {
-                  if (a.timestamp === 'aggregate') {
-                    runState.Report.aggregate[plugin.__name] = a.value;
-                  } else {
-                    let ir = _.findWhere(
-                      runState.Report.intermediate,
-                      {timestamp: a.timestamp});
-                    ir[plugin.__name] = a.value;
-                  }
-                });
-              } else {
-                runState.Report.aggregate[plugin.__name] = report;
-              }
-            }
-          }
-        });
-
         return ee.emit('done', runState.Report);
       } else {
         debug('Pending requests: %s', runState.pendingRequests);

--- a/lib/stats2.js
+++ b/lib/stats2.js
@@ -8,11 +8,69 @@ const L = require('lodash');
 const sl = require('stats-lite');
 
 module.exports = {
-  create: create
+  create: create,
+  combine: combine
 };
 
+/**
+ * Create a new stats object
+ */
 function create() {
   return new Stats();
+}
+
+/**
+ * Combine several stats objects into one
+ */
+function combine(statsObjects) {
+  let result = create();
+  L.each(statsObjects, function(stats) {
+    L.each(stats._entries, function(entry) {
+      result._entries.push(entry);
+    });
+    L.each(stats._latencies, function(latency) {
+      result._latencies.push(latency);
+    });
+    result._generatedScenarios += stats._generatedScenarios;
+    result._completedScenarios += stats._completedScenarios;
+    L.each(stats._codes, function(count, code) {
+      if(result._codes[code]) {
+        result._codes[code] += count;
+      } else {
+        result._codes[code] = count;
+      }
+    });
+    L.each(stats._errors, function(count, error) {
+      if(result._errors[error]) {
+        result._errors[error] += count;
+      } else {
+        result._errors[error] = count;
+      }
+    });
+    L.each(stats._requestTimestamps, function(timestamp) {
+      result._requestTimestamps.push(timestamp);
+    });
+    result._completedRequests += stats._completedRequests;
+    L.each(stats._scenarioLatencies, function(latency) {
+      result._scenarioLatencies.push(latency);
+    });
+    result._matches += stats._matches;
+
+    L.each(stats.customStats, function(values, name) {
+      if (result.customStats[name]) {
+        result.customStats[name] = [];
+      }
+
+      L.each(values, function(v) {
+        result.customStats[name].push(v);
+      });
+    });
+
+    result._concurrency += stats._concurrency || 0;
+    result._pendingRequests += stats._pendingRequests;
+  });
+
+  return result;
 }
 
 function Stats() {
@@ -135,6 +193,11 @@ Stats.prototype.report = function() {
     };
   });
 
+  if (this._concurrency !== null) {
+    result.concurrency = this._concurrency;
+  }
+  result.pendingRequests = this._pendingRequests;
+
   return result;
 };
 
@@ -159,6 +222,9 @@ Stats.prototype.reset = function() {
   this._scenarioLatencies = [];
   this._matches = 0;
   this._customStats = {};
+  this._concurrency = null;
+  this._pendingRequests = 0;
+
   return this;
 };
 

--- a/lib/stats2.js
+++ b/lib/stats2.js
@@ -137,6 +137,10 @@ Stats.prototype.addMatch = function() {
   return this;
 };
 
+Stats.prototype.clone = function() {
+  return L.cloneDeep(this);
+};
+
 Stats.prototype.report = function() {
   let result = {};
 

--- a/test/test_basic_auth.js
+++ b/test/test_basic_auth.js
@@ -7,10 +7,10 @@ test('HTTP basic auth', (t) => {
   const script = require('./scripts/hello_basic_auth.json');
 
   let ee = runner(script);
-  ee.on('done', (stats) => {
-    let requests = stats.aggregate.requestsCompleted;
-    let code200 = stats.aggregate.codes[200];
-    let code401 = stats.aggregate.codes[401];
+  ee.on('done', (report) => {
+    let requests = report.requestsCompleted;
+    let code200 = report.codes[200];
+    let code401 = report.codes[401];
     t.assert(
       requests > 0 && (code200 === code401),
       'Should have an equal non-zero number of 200s and 401s');

--- a/test/test_capture.js
+++ b/test/test_capture.js
@@ -18,10 +18,10 @@ test('Capture - headers', (t) => {
   const fn = './scripts/captures-header.json';
   const script = require(fn);
   let ee = runner(script);
-  ee.on('done', function(stats) {
+  ee.on('done', function(report) {
     // This will fail if header capture isn't working
-    t.assert(!stats.aggregate.codes[403], 'No unauthorized responses');
-    t.assert(stats.aggregate.codes[200] > 0, 'Successful responses');
+    t.assert(!report.codes[403], 'No unauthorized responses');
+    t.assert(report.codes[200] > 0, 'Successful responses');
     t.end();
   });
   ee.run();
@@ -40,10 +40,10 @@ test('Capture - JSON', (t) => {
 
     let ee = runner(script, parsedData, {});
 
-    ee.on('done', function(stats) {
-      let c200 = stats.aggregate.codes[200];
-      let c201 = stats.aggregate.codes[201];
-      let c404 = stats.aggregate.codes[404];
+    ee.on('done', function(report) {
+      let c200 = report.codes[200];
+      let c201 = report.codes[201];
+      let c404 = report.codes[404];
       let cond = c201 * 2 === c200 + c404;
       t.assert(cond,
                'There should be a 200 and a 404 for every 201');
@@ -74,9 +74,9 @@ test('Capture - XML', (t) => {
 
     let ee = runner(script, parsedData, {});
 
-    ee.on('done', function(stats) {
-      t.assert(stats.aggregate.codes[200] > 0, 'Should have a few 200s');
-      t.assert(stats.aggregate.codes[404] === undefined, 'Should have no 404s');
+    ee.on('done', function(report) {
+      t.assert(report.codes[200] > 0, 'Should have a few 200s');
+      t.assert(report.codes[404] === undefined, 'Should have no 404s');
       t.end();
     });
 
@@ -89,9 +89,9 @@ test('Capture - Random value from array', (t) => {
   const script = require(fn);
   let ee = runner(script);
 
-  ee.on('done', (stats) => {
-    t.assert(stats.aggregate.codes[200] > 0, 'Should have a few 200s');
-    t.assert(stats.aggregate.codes[404] === undefined, 'Should have no 404s');
+  ee.on('done', (report) => {
+    t.assert(report.codes[200] > 0, 'Should have a few 200s');
+    t.assert(report.codes[404] === undefined, 'Should have no 404s');
     t.end();
   });
 
@@ -102,10 +102,10 @@ test('Capture - RegExp', (t) => {
   const fn = './scripts/captures-regexp.json';
   const script = require(fn);
   let ee = runner(script);
-  ee.on('done', (stats) => {
-      let c200 = stats.aggregate.codes[200];
-      let c201 = stats.aggregate.codes[201];
-      let c404 = stats.aggregate.codes[404];
+  ee.on('done', (report) => {
+      let c200 = report.codes[200];
+      let c201 = report.codes[201];
+      let c404 = report.codes[404];
       let cond = c201 * 2 === c200 + c404;
       t.assert(cond,
                'There should be a 200 and a 404 for every 201');

--- a/test/test_config_variables.js
+++ b/test/test_config_variables.js
@@ -6,9 +6,9 @@ const runner = require('../lib/runner').runner;
 test('config variables', function(t) {
   const script = require('./scripts/config_variables.json');
   const ee = runner(script);
-  ee.on('done', function(stats) {
-    t.assert(stats.aggregate.codes[200] > 0, 'there are 200s for /');
-    t.assert(stats.aggregate.codes[404] > 0, 'there are 404s for /will/404');
+  ee.on('done', function(report) {
+    t.assert(report.codes[200] > 0, 'there are 200s for /');
+    t.assert(report.codes[404] > 0, 'there are 404s for /will/404');
     t.end();
   });
   ee.run();

--- a/test/test_cookies.js
+++ b/test/test_cookies.js
@@ -8,7 +8,7 @@ var request = require('request');
 test('cookie jar', function(t) {
   var script = require('./scripts/cookies.json');
   var ee = runner(script);
-  ee.on('done', function(stats) {
+  ee.on('done', function(report) {
     request({
       method: 'GET',
       url: 'http://127.0.0.1:3003/_stats',
@@ -19,11 +19,11 @@ test('cookie jar', function(t) {
         return t.fail();
       }
 
-      var ok = l.size(body.cookies) >= stats.aggregate.scenariosCompleted;
+      var ok = l.size(body.cookies) >= report.scenariosCompleted;
       t.assert(ok, 'Each scenario had a unique cookie');
       if (!ok) {
         console.log(body);
-        console.log(stats);
+        console.log(report);
       }
       t.end();
     });
@@ -34,10 +34,10 @@ test('cookie jar', function(t) {
 test('default cookies', function(t) {
   var script = require('./scripts/defaults_cookies.json');
   var ee = runner(script);
-  ee.on('done', function(stats) {
-    t.assert(stats.aggregate.codes[200] && stats.aggregate.codes[200] > 0,
+  ee.on('done', function(report) {
+    t.assert(report.codes[200] && report.codes[200] > 0,
       'There should be some 200s');
-    t.assert(stats.aggregate.codes[403] === undefined,
+    t.assert(report.codes[403] === undefined,
       'There should be no 403s');
     t.end();
   });
@@ -48,10 +48,10 @@ test('no default cookie', function(t) {
   var script = require('./scripts/defaults_cookies.json');
   delete script.config.defaults.cookie;
   var ee = runner(script);
-  ee.on('done', function(stats) {
-    t.assert(stats.aggregate.codes[403] && stats.aggregate.codes[403] > 0,
+  ee.on('done', function(report) {
+    t.assert(report.codes[403] && report.codes[403] > 0,
       'There should be some 403s');
-    t.assert(stats.aggregate.codes[200] === undefined,
+    t.assert(report.codes[200] === undefined,
       'There should be no 200s');
     t.end();
   });

--- a/test/test_environments.js
+++ b/test/test_environments.js
@@ -8,12 +8,12 @@ var url = require('url');
 test('environments - override target', function(t) {
   var script = require('./scripts/hello_environments.json');
   var ee = runner(script, null, {environment: 'production'});
-  ee.on('done', function(stats) {
-    t.assert(stats.aggregate.requestsCompleted === 0,
+  ee.on('done', function(report) {
+    t.assert(report.requestsCompleted === 0,
       'there should be no completed requests');
     t.assert(
-      stats.aggregate.errors.ETIMEDOUT &&
-      stats.aggregate.errors.ETIMEDOUT > 1,
+      report.errors.ETIMEDOUT &&
+      report.errors.ETIMEDOUT > 1,
       'there should ETIMEDOUT errors');
     t.end();
   });
@@ -28,11 +28,11 @@ test('environments - override target and phases', function(t) {
   target.listen(
     url.parse(script.config.environments.staging.target).port || 80);
   var ee = runner(script, null, {environment: 'staging'});
-  ee.on('done', function(stats) {
+  ee.on('done', function(report) {
     var completedAt = process.hrtime(startedAt);
     var delta = ((completedAt[0] * 1e9) + completedAt[1]) / 1e6;
 
-    t.assert(stats.aggregate.codes[200], 'stats should not be empty');
+    t.assert(report.codes[200], 'stats should not be empty');
     t.assert(delta >= 20 * 1000, 'should\'ve run for 20 seconds');
     target.stop();
     t.end();

--- a/test/test_if.js
+++ b/test/test_if.js
@@ -8,15 +8,15 @@ test('ifTrue', (t) => {
   const script = require('./scripts/iftrue.json');
 
   let ee = runner(script);
-  ee.on('done', (stats) => {
-    let requests = stats.aggregate.codes[201];
+  ee.on('done', (report) => {
+    let requests = report.codes[201];
     let expected = 10;
     t.assert(
       requests === expected,
       'Should have ' + expected + ' 201s (pet created)');
-    t.assert(stats.aggregate.codes[404] === expected,
+    t.assert(report.codes[404] === expected,
              'Should have ' + expected + '404s');
-    t.assert(!stats.aggregate.codes[200],
+    t.assert(!report.codes[200],
              'Should not have 200s');
     t.end();
   });

--- a/test/test_loop.js
+++ b/test/test_loop.js
@@ -8,9 +8,9 @@ test('simple loop', (t) => {
   const script = require('./scripts/loop.json');
 
   let ee = runner(script);
-  ee.on('done', (stats) => {
-    let scenarios = stats.aggregate.scenariosCompleted;
-    let requests = stats.aggregate.requestsCompleted;
+  ee.on('done', (report) => {
+    let scenarios = report.scenariosCompleted;
+    let requests = report.requestsCompleted;
     let loopCount = script.scenarios[0].flow[0].count;
     let expected = scenarios * loopCount * 2;
     t.assert(
@@ -25,12 +25,12 @@ test('loop with range', (t) => {
   const script = require('./scripts/loop_range.json');
 
   let ee = runner(script);
-  ee.on('done', (stats) => {
-    let scenarios = stats.aggregate.scenariosCompleted;
-    let requests = stats.aggregate.requestsCompleted;
+  ee.on('done', (report) => {
+    let scenarios = report.scenariosCompleted;
+    let requests = report.requestsCompleted;
     let expected = scenarios * 3 * 2;
-    let code200 = stats.aggregate.codes[200];
-    let code404 = stats.aggregate.codes[404];
+    let code200 = report.codes[200];
+    let code404 = report.codes[404];
 
     t.assert(
       requests === expected,

--- a/test/test_misc.js
+++ b/test/test_misc.js
@@ -34,9 +34,9 @@ l.each(SCRIPTS, function(fn) {
     ee.on('stats', function(stats) {
       t.ok(stats, 'intermediate stats event emitted');
     });
-    ee.on('done', function(stats) {
-      var requests = stats.aggregate.requestsCompleted;
-      var scenarios = stats.aggregate.scenariosCompleted;
+    ee.on('done', function(report) {
+      var requests = report.requestsCompleted;
+      var scenarios = report.scenariosCompleted;
       console.log('requests = %s, scenarios = %s', requests, scenarios);
 
       t.assert(completedPhases === script.config.phases.length,

--- a/test/test_multiple_payloads.js
+++ b/test/test_multiple_payloads.js
@@ -33,11 +33,11 @@ test('single payload', function(t) {
       t.ok(stats, 'intermediate stats event emitted');
     });
 
-    ee.on('done', function(stats) {
-      let requests = stats.aggregate.requestsCompleted;
-      let scenarios = stats.aggregate.scenariosCompleted;
-      t.assert(stats.aggregate.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
-      t.assert(stats.aggregate.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
+    ee.on('done', function(report) {
+      let requests = report.requestsCompleted;
+      let scenarios = report.scenariosCompleted;
+      t.assert(report.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
+      t.assert(report.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
       t.end();
     });
 
@@ -83,12 +83,12 @@ test('multiple_payloads', function(t) {
         t.ok(stats, 'intermediate stats event emitted');
       });
 
-      ee.on('done', function(stats) {
-        let requests = stats.aggregate.requestsCompleted;
-        let scenarios = stats.aggregate.scenariosCompleted;
-        t.assert(stats.aggregate.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
-        t.assert(stats.aggregate.codes[200] > 0, 'There are some 200s (URLs constructed from urls.csv)');
-        t.assert(stats.aggregate.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
+      ee.on('done', function(report) {
+        let requests = report.requestsCompleted;
+        let scenarios = report.scenariosCompleted;
+        t.assert(report.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
+        t.assert(report.codes[200] > 0, 'There are some 200s (URLs constructed from urls.csv)');
+        t.assert(report.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
         t.end();
       });
 

--- a/test/test_probability.js
+++ b/test/test_probability.js
@@ -8,8 +8,8 @@ test('request probability', (t) => {
   const script = require('./scripts/probability.json');
 
   let ee = runner(script);
-  ee.on('done', (stats) => {
-    let requests = stats.aggregate.requestsCompleted;
+  ee.on('done', (report) => {
+    let requests = report.requestsCompleted;
     t.assert(requests < 130,
              'Should have completed ~10% = ~100 requests in total, actually completed ' + requests);
     t.end();

--- a/test/test_reuse.js
+++ b/test/test_reuse.js
@@ -27,7 +27,7 @@ test('reuse', function(t) {
   }
   expected *= weightedFlowLengths;
   ee.on('stats', function(stats) {
-    intermediate.push(stats);
+    intermediate.push(stats.report());
   });
   ee.on('done', function(report) {
     let total = 0;

--- a/test/test_think.js
+++ b/test/test_think.js
@@ -7,7 +7,7 @@ test('think', function(t) {
   var script = require('./scripts/thinks_http.json');
   var ee = runner(script);
   ee.on('done', function(stats) {
-    t.assert('stats should be empty', stats.codes === {});
+    t.assert('stats should be empty', stats.report().codes === {});
     t.end();
   });
   ee.run();

--- a/test/test_tls.js
+++ b/test/test_tls.js
@@ -19,8 +19,8 @@ server.listen(3002);
 test('tls strict', function(t) {
   var script = require('./scripts/tls-strict.json');
   var ee = runner(script);
-  ee.on('done', function(stats) {
-    var rejected = stats.aggregate.errors.DEPTH_ZERO_SELF_SIGNED_CERT;
+  ee.on('done', function(report) {
+    var rejected = report.errors.DEPTH_ZERO_SELF_SIGNED_CERT;
     t.assert(rejected, 'requests to self-signed tls certs fail by default');
 
     t.end();
@@ -31,8 +31,8 @@ test('tls strict', function(t) {
 test('tls lax', function(t) {
   var script = require('./scripts/tls-lax.json');
   var ee = runner(script);
-  ee.on('done', function(stats) {
-    var rejected = stats.aggregate.errors.DEPTH_ZERO_SELF_SIGNED_CERT;
+  ee.on('done', function(report) {
+    var rejected = report.errors.DEPTH_ZERO_SELF_SIGNED_CERT;
     var reason = 'requests to self-signed tls certs pass ' +
                  'when `rejectUnauthorized` is false';
 


### PR DESCRIPTION
These are breaking changes and will need a major semver bump.

- `done` event will now return **only** the aggregate report
- `stats` events will now return stats objects rather than reports