### PR TITLE
Allow `config.ws` to set options for WebSocket engine

### DIFF
--- a/lib/engine_ws.js
+++ b/lib/engine_ws.js
@@ -65,9 +65,13 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
   let config = this.config;
 
   function zero(callback) {
-    let ws = new WebSocket(config.target);
+    let tls = config.tls || {}; // TODO: config.tls is deprecated
+    let options = _.extend(tls, config.ws);
+
+    ee.emit('started');
+
+    let ws = new WebSocket(config.target, options);
     ws.on('open', function() {
-      ee.emit('started');
       return callback(null, {ws: ws});
     });
     ws.once('error', function(err) {

--- a/test/run.sh
+++ b/test/run.sh
@@ -8,10 +8,16 @@ node test/targets/simple_socketio.js &
 io_pid=$!
 node test/targets/express_socketio.js &
 express_pid=$!
+node test/targets/ws_tls.js &
+ws_tls_pid=$!
+
 node test/index.js
 test_status=$?
+
 kill $simple_pid
 kill $ws_pid
 kill $io_pid
 kill $express_pid
+kill $ws_tls_pid
+
 exit $test_status

--- a/test/targets/ws_tls.js
+++ b/test/targets/ws_tls.js
@@ -6,7 +6,7 @@ const debug = require('debug')('test:target:ws_tls');
 const WebSocketServer = require('ws').Server;
 
 var options = {
-  port: 9090,
+  port: 9443,
   key: fs.readFileSync('./test/certs/private-key.pem'),
   cert: fs.readFileSync('./test/certs/public-cert.pem')
 };
@@ -20,7 +20,7 @@ var app = https.createServer(
     res.writeHead(200);
     res.end();
   }).listen(options.port, function() {
-    debug('Listening on :9090');
+    debug('Listening on :9443');
   });
 
 const wss = new WebSocketServer({ server: app });

--- a/test/targets/ws_tls.js
+++ b/test/targets/ws_tls.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const fs = require('fs');
+const https = require('https');
+const debug = require('debug')('test:target:ws_tls');
+const WebSocketServer = require('ws').Server;
+
+var options = {
+  port: 9090,
+  key: fs.readFileSync('./test/certs/private-key.pem'),
+  cert: fs.readFileSync('./test/certs/public-cert.pem')
+};
+
+var app = https.createServer(
+  {
+    key: options.key,
+    cert: options.cert
+  },
+  function(req, res) {
+    res.writeHead(200);
+    res.end();
+  }).listen(options.port, function() {
+    debug('Listening on :9090');
+  });
+
+const wss = new WebSocketServer({ server: app });
+
+wss.on('connection', function(client) {
+  debug('+ client');
+  client.on('message', function(message) {
+    debug(message);
+  });
+});

--- a/test/ws/scripts/extra_options.json
+++ b/test/ws/scripts/extra_options.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "target": "wss://localhost:9090",
+    "phases": [
+      {"duration": 1, "arrivalCount": 1}
+    ],
+    "ws": {
+      "rejectUnauthorized": false
+    }
+  },
+  "scenarios": [
+    {
+      "engine": "ws",
+      "flow": [
+        {"send": "hello"}
+      ]
+    }
+  ]
+}

--- a/test/ws/scripts/extra_options.json
+++ b/test/ws/scripts/extra_options.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "target": "wss://localhost:9090",
+    "target": "wss://localhost:9443",
     "phases": [
       {"duration": 1, "arrivalCount": 1}
     ],

--- a/test/ws/test_options.js
+++ b/test/ws/test_options.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const test = require('tape');
+const vuserLauncher = require('../../lib/runner').runner;
+
+//
+// If config.ws.rejectUnauthorized is not set, we will have an error.
+// Otherwise the test will run fine.
+//
+
+test('TLS options for WebSocket', function(t) {
+  const script = require('./scripts/extra_options.json');
+  const sessions = vuserLauncher(script);
+  sessions.on('done', function(report) {
+    t.assert(Object.keys(report.errors).length === 0,
+             'Test ran without errors');
+
+    // Now remove TLS options and rerun - should have an error
+    delete script.config.ws;
+    const sessions2 = vuserLauncher(script);
+    sessions2.on('done', function(report2) {
+      t.assert(Object.keys(report2.errors).length === 1,
+               'Test ran with one error: ' +
+               (Object.keys(report2.errors)[0]));
+      t.end();
+    });
+    sessions2.run();
+  });
+
+  sessions.run();
+});


### PR DESCRIPTION
The patch address both of these issues:
- https://github.com/shoreditch-ops/artillery/issues/150
- https://github.com/shoreditch-ops/artillery/issues/98