### PR TITLE
comparing object literals in socket.io payload

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -7,6 +7,7 @@
 const async = require('async');
 const _ = require('lodash');
 const io = require('socket.io-client');
+const deepEqual = require('deep-equal');
 const debug = require('debug')('socketio');
 const engineUtil = require('./engine_util');
 const EngineHttp = require('./engine_http');
@@ -43,7 +44,7 @@ function isResponseRequired(spec) {
 function processResponse(ee, data, expectedData) {
   let err = null;
 
-  if (expectedData && (data !== expectedData)) {
+  if (expectedData && !deepEqual(data, expectedData)) {
     debug(data);
     err = 'data is not valid';
     ee.emit('error', err);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "async": "1.5.2",
     "cheerio": "0.20.0",
     "debug": "2.2.0",
+    "deep-equal": "^1.0.1",
     "esprima": "2.5.0",
     "filtrex": "0.5.4",
     "hogan.js": "^3.0.2",


### PR DESCRIPTION
In Socket.io, data payload can be string and JSON object literal.
When I use JSON payload such like `{"name": "john"}`,  `data is not valid` error is occured. Because `data !== expectedData` couldn't compare JSON object.
But `deep-equal` could compare both, string and JSON object.