### PR TITLE
Catch exceptions coming from capture transforms

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -533,7 +533,7 @@ function captureOrMatch(params, response, context, done) {
               spec.transform);
 
             debugCapture('transform: %s = %s', spec.as, result.captures[spec.as]);
-            result.captures[spec.as] = transformedValue;
+            result.captures[spec.as] = transformedValue !== null ? transformedValue : extractedValue;
           }
         }
 

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -125,7 +125,12 @@ function template(o, context) {
 function evil(sandbox, code) {
   let context = vm.createContext(sandbox);
   let script = new vm.Script(code);
-  return script.runInContext(context);
+  try {
+    return script.runInContext(context);
+  }
+  catch(e) {
+    return null;
+  }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "author": "Hassy Veldstra <h@veldstra.org>",
   "contributors": [
-    "Kieran Gorman (https://github.com/kjgorman)"
+    "Kieran Gorman (https://github.com/kjgorman)",
+    "Judson Neer (https://github.com/lordjabez)"
   ],
   "license": "MPL-2.0",
   "dependencies": {

--- a/test/scripts/captures.json
+++ b/test/scripts/captures.json
@@ -24,6 +24,10 @@
               "transform": "this.id.toUpperCase()",
               "as": "id"
             }, {
+              "json": "$.doesnotexist",
+              "transform": "this.doesnotexist.toUpperCase()",
+              "as": "doesnotexist"
+            }, {
               "regexp": ".+",
               "as": "id2"
             }]


### PR DESCRIPTION
If any exception occurs in a capture transform, it currently propagates upwards and terminates the load test. This makes for overly-complicated transform logic in situations where the capture value might not actually be present in the response.

The change here captures all exceptions coming from a transform, and simply uses the original capture value if one occurs.