### PR TITLE
Increase default HTTP timeout

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -91,7 +91,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
     let params = requestSpec[method.toLowerCase()];
     let uri = maybePrependBase(template(params.url, context), config);
     let tls = config.tls || {};
-    let timeout = config.timeout || _.get(config, 'http.timeout') || 10;
+    let timeout = config.timeout || _.get(config, 'http.timeout') || 120;
 
     if (!engineUtil.isProbableEnough(params)) {
       return process.nextTick(function() {


### PR DESCRIPTION
Increase default HTTP timeout to 120 seconds.

10s is too aggressive and many users don’t realise they’re
overloading their server because the latency numbers look OK-ish
and seeing ETIMEDOUT errors doesn't make intuitive sense.