### PR TITLE
Include request body in debug output when DEBUG=http is set

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -7,8 +7,10 @@
 const async = require('async');
 const _ = require('lodash');
 const request = require('request');
+
 const debug = require('debug')('http');
 const debugResponse = require('debug')('http:response');
+const debugFullBody = require('debug')('http:full_body');
 const VERSION = require('../package.json').version;
 const USER_AGENT = 'artillery ' + VERSION + ' (https://artillery.io)';
 const engineUtil = require('./engine_util');
@@ -212,12 +214,32 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         }
 
         function requestCallback(err, res, body) {
-          debug('request: %s', JSON.stringify({
-            uri: requestParams.uri,
-            method: requestParams.method,
-            headers: requestParams.headers,
-            json: requestParams.json
-          }, null, 2));
+
+          if (process.env.DEBUG) {
+            let requestInfo = {
+              uri: requestParams.uri,
+              method: requestParams.method,
+              headers: requestParams.headers
+            };
+            if (requestParams.json && typeof requestParams.json !== 'boolean') {
+              requestInfo.json = requestParams.json;
+            }
+
+            // If "json" is set to an object, it will be serialised and sent as body and the value of the "body" attribute will be ignored.
+            if (requestParams.body && typeof requestParams.json !== 'object') {
+              if (process.env.DEBUG.indexOf('http:full_body') > -1) {
+                // Show the entire body
+                requestInfo.body = requestParams.body;
+              } else {
+                // Only show the beginning of long bodies
+                requestInfo.body = requestParams.body.substring(0, 512);
+                if (requestParams.body.length > 512) {
+                  requestInfo.body += ' ...';
+                }
+              }
+            }
+            debug('request: %s', JSON.stringify(requestInfo, null, 2));
+          }
 
           if (err) {
             let errCode = err.code || err.message;


### PR DESCRIPTION
Output will be truncated to only show the first 512 characters for large bodies, unless `DEBUG=http:full_body` is set, which will make Artillery print everything.