### PR TITLE
Configurable socket namespace per emit action

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -187,14 +187,14 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
       }
 
       return f(context, callback, socket);
-    })
+    });
   }
 
   return preStep;
 };
 
 SocketIoEngine.prototype.getSocket = function(namespace, context, cb) {
-  context.namespaces = context.namespaces||{};
+  context.namespaces = context.namespaces || {};
 
   if(!context.namespaces[namespace]) {
     let target = this.config.target + namespace;
@@ -208,7 +208,7 @@ SocketIoEngine.prototype.getSocket = function(namespace, context, cb) {
     });
     context.namespaces[namespace].on('connect_error', function(err){
       cb(err);
-    })
+    });
   } else {
     cb(null, context.namespaces[namespace]);
   }
@@ -222,9 +222,9 @@ SocketIoEngine.prototype.closeContextSockets = function (context) {
     var namespaces = Object.keys(context.namespaces);
     namespaces.forEach(function(namespace){
       context.namespaces[namespace].disconnect();
-    })
+    });
   }
-}
+};
 
 
 SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
@@ -267,7 +267,7 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
             debug(err);
           }
           if (context) {
-            self.closeContextSockets(context)
+            self.closeContextSockets(context);
           }
           return callback(err, context);
         });

--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -118,10 +118,10 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
     return engineUtil.createLoopWithCount(requestSpec.count || -1, steps);
   }
 
-  let f = function(context, callback) {
+  let f = function(context, callback, socketio) {
     // Only process emit requests; delegate the rest to the HTTP engine (or think utility)
     if (requestSpec.think) {
-      return engineUtil.createThink(requestSpec, _.get(self.config, 'defaults.think', {}));
+      return engineUtil.createThink(requestSpec);
     }
     if (!requestSpec.emit) {
       let delegateFunc = self.httpDelegate.step(requestSpec, ee);
@@ -148,19 +148,19 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
       };
       // Listen for the socket.io response on the specified channel
       let done = false;
-      context.socketio.on(response.channel, function receive(data) {
+      socketio.on(response.channel, function receive(data) {
         done = true;
         processResponse(ee, data, response, context, function(err) {
           if (!err) {
             markEndTime(ee, context, startedAt);
           }
           // Stop listening on the response channel
-          context.socketio.off(response.channel);
+          socketio.off(response.channel);
           return callback(err, context);
         });
       });
       // Send the data on the specified socket.io channel
-      context.socketio.emit(outgoing.channel, outgoing.data);
+      socketio.emit(outgoing.channel, outgoing.data);
       // If we don't get a response within the timeout, fire an error
       let waitTime = self.config.timeout || 10;
       waitTime *= 1000;
@@ -173,13 +173,43 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
       }, waitTime);
     } else {
       // No return data is expected, so emit without a listener
-      context.socketio.emit(outgoing.channel, outgoing.data);
+      socketio.emit(outgoing.channel, outgoing.data);
       markEndTime(ee, context, startedAt);
       return callback(null, context);
     }
   };
 
-  return f;
+  function preStep(context, callback){
+    var namespace = requestSpec.emit.namespace||"/";
+    self.getSocket(namespace , context, function(err, socket){
+      if(err) return callback(err, context);
+
+      return f(context, callback, socket);
+    })
+  }
+
+  return preStep;
+};
+
+SocketIoEngine.prototype.getSocket = function(namespace, context, cb) {
+  context.namespaces = context.namespaces||{};
+
+  if(!context.namespaces[namespace]) {
+    let target = this.config.target + namespace;
+    let tls = config.tls || {};
+    let options = _.extend({}, tls);
+
+    context.namespaces[namespace] = io.connect(target, options);
+
+    context.namespaces[namespace].on('connect', function(){
+      cb(null, context.namespaces[namespace]);
+    });
+    context.namespaces[namespace].on('connect_error', function(err){
+      cb(err);
+    })
+  } else {
+    cb(null, context.namespaces[namespace]);
+  }
 };
 
 SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
@@ -220,10 +250,22 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
         if (err) {
           debug(err);
         }
-        if (context && context.socketio) {
-          context.socketio.disconnect();
+        if (context) {
+          disconnectContextSockets(context)
         }
         return callback(err, context);
       });
   };
 };
+
+function disconnectContextSockets(context) {
+  if(context.socketio) {
+    context.socketio.disconnect();
+  }
+  if(context.namespaces && Object.keys(context.namespaces).length > 0) {
+    var namespaces = Object.keys(context.namespaces);
+    namespaces.forEach(function(namespace){
+      context.namespaces[namespace].disconnect();
+    })
+  }
+}

--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -118,10 +118,10 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
     return engineUtil.createLoopWithCount(requestSpec.count || -1, steps);
   }
 
-  let f = function(context, callback, socketio) {
+  let f = function(context, callback) {
     // Only process emit requests; delegate the rest to the HTTP engine (or think utility)
     if (requestSpec.think) {
-      return engineUtil.createThink(requestSpec);
+      return engineUtil.createThink(requestSpec, _.get(self.config, 'defaults.think', {}));
     }
     if (!requestSpec.emit) {
       let delegateFunc = self.httpDelegate.step(requestSpec, ee);
@@ -129,9 +129,10 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
     }
     ee.emit('request');
     let startedAt = process.hrtime();
+    let socketio = context.sockets[requestSpec.emit.namespace] || null;
 
-    if (!(requestSpec.emit && requestSpec.emit.channel)) {
-      ee.emit('error', 'invalid arguments');
+    if (!(requestSpec.emit && requestSpec.emit.channel && socketio)) {
+      return ee.emit('error', 'invalid arguments');
     }
 
     let outgoing = {
@@ -180,41 +181,44 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
   };
 
   function preStep(context, callback){
-    var namespace = requestSpec.emit.namespace || "/";
-    self.getSocket(namespace, context, function(err, socket){
+    // Set default namespace in emit action
+    requestSpec.emit.namespace = requestSpec.emit.namespace || "/";
+
+    self.loadContextSocket(requestSpec.emit.namespace, context, function(err, socket){
       if(err) {
         return callback(err, context);
       }
 
-      return f(context, callback, socket);
+      return f(context, callback);
     });
   }
 
   if(requestSpec.emit) {
+
     return preStep;
   } else {
     return f;
   }
 };
 
-SocketIoEngine.prototype.getSocket = function(namespace, context, cb) {
-  context.namespaces = context.namespaces || {};
+SocketIoEngine.prototype.loadContextSocket = function(namespace, context, cb) {
+  context.sockets = context.sockets || {};
 
-  if(!context.namespaces[namespace]) {
+  if(!context.sockets[namespace]) {
     let target = this.config.target + namespace;
     let tls = this.config.tls || {};
     let options = _.extend({}, tls);
 
-    context.namespaces[namespace] = io.connect(target, options);
+    context.sockets[namespace] = io.connect(target, options);
 
-    context.namespaces[namespace].on('connect', function(){
-      cb(null, context.namespaces[namespace]);
+    context.sockets[namespace].on('connect', function(){
+      cb(null, context.sockets[namespace]);
     });
-    context.namespaces[namespace].on('connect_error', function(err){
-      cb(err);
+    context.sockets[namespace].on('connect_error', function(err){
+      cb(err, null);
     });
   } else {
-    cb(null, context.namespaces[namespace]);
+    cb(null, context.sockets[namespace]);
   }
 };
 
@@ -222,10 +226,10 @@ SocketIoEngine.prototype.closeContextSockets = function (context) {
   if(context.socketio) {
     context.socketio.disconnect();
   }
-  if(context.namespaces && Object.keys(context.namespaces).length > 0) {
-    var namespaces = Object.keys(context.namespaces);
+  if(context.sockets && Object.keys(context.sockets).length > 0) {
+    var namespaces = Object.keys(context.sockets);
     namespaces.forEach(function(namespace){
-      context.namespaces[namespace].disconnect();
+      context.sockets[namespace].disconnect();
     });
   }
 };

--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -180,9 +180,11 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
   };
 
   function preStep(context, callback){
-    var namespace = requestSpec.emit.namespace||"/";
-    self.getSocket(namespace , context, function(err, socket){
-      if(err) return callback(err, context);
+    var namespace = requestSpec.emit.namespace || "/";
+    self.getSocket(namespace, context, function(err, socket){
+      if(err) {
+        return callback(err, context);
+      }
 
       return f(context, callback, socket);
     })
@@ -196,7 +198,7 @@ SocketIoEngine.prototype.getSocket = function(namespace, context, cb) {
 
   if(!context.namespaces[namespace]) {
     let target = this.config.target + namespace;
-    let tls = config.tls || {};
+    let tls = this.config.tls || {};
     let options = _.extend({}, tls);
 
     context.namespaces[namespace] = io.connect(target, options);
@@ -247,9 +249,9 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
   return function scenario(initialContext, callback) {
     initialContext._successCount = 0;
     initialContext._pendingRequests = _.size(
-      _.reject(scenarioSpec, function(rs) {
-        return (typeof rs.think === 'number');
-      }));
+        _.reject(scenarioSpec, function(rs) {
+          return (typeof rs.think === 'number');
+        }));
 
     let steps = _.flatten([
       function z(cb) {
@@ -259,16 +261,15 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
     ]);
 
     async.waterfall(
-      steps,
-      function scenarioWaterfallCb(err, context) {
-        if (err) {
-          debug(err);
-        }
-        if (context) {
-          self.closeContextSockets(context)
-        }
-        return callback(err, context);
-      });
+        steps,
+        function scenarioWaterfallCb(err, context) {
+          if (err) {
+            debug(err);
+          }
+          if (context) {
+            self.closeContextSockets(context)
+          }
+          return callback(err, context);
+        });
   };
 };
-

--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -190,7 +190,11 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
     });
   }
 
-  return preStep;
+  if(requestSpec.emit) {
+    return preStep;
+  } else {
+    return f;
+  }
 };
 
 SocketIoEngine.prototype.getSocket = function(namespace, context, cb) {

--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -212,8 +212,22 @@ SocketIoEngine.prototype.getSocket = function(namespace, context, cb) {
   }
 };
 
+SocketIoEngine.prototype.closeContextSockets = function (context) {
+  if(context.socketio) {
+    context.socketio.disconnect();
+  }
+  if(context.namespaces && Object.keys(context.namespaces).length > 0) {
+    var namespaces = Object.keys(context.namespaces);
+    namespaces.forEach(function(namespace){
+      context.namespaces[namespace].disconnect();
+    })
+  }
+}
+
+
 SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
   let config = this.config;
+  let self = this;
 
   function zero(callback, context) {
     let tls = config.tls || {};
@@ -251,21 +265,10 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
           debug(err);
         }
         if (context) {
-          disconnectContextSockets(context)
+          self.closeContextSockets(context)
         }
         return callback(err, context);
       });
   };
 };
 
-function disconnectContextSockets(context) {
-  if(context.socketio) {
-    context.socketio.disconnect();
-  }
-  if(context.namespaces && Object.keys(context.namespaces).length > 0) {
-    var namespaces = Object.keys(context.namespaces);
-    namespaces.forEach(function(namespace){
-      context.namespaces[namespace].disconnect();
-    })
-  }
-}

--- a/test/scripts/namespaces_socketio.json
+++ b/test/scripts/namespaces_socketio.json
@@ -1,0 +1,22 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:9091",
+      "tls": {
+        "rejectUnauthorized": true
+      },
+      "phases": [
+        {"duration": 15, "arrivalRate": 1}
+      ]
+  },
+  "scenarios": [
+    {
+      "engine": "socketio",
+      "flow": [
+        {"emit": { "namespace": "/nsp1", "channel": "echo", "data": "hello ns1", "response": { "channel": "echoed:nsp1", "data": "hello ns1"} }},
+        {"think": 1},
+        {"emit": { "namespace": "/nsp2", "channel": "echo", "data": "hello ns2", "response": { "channel": "echoed:nsp2", "data": "hello ns2"} }},
+        {"think": 1}
+      ]
+    }
+  ]
+}

--- a/test/targets/simple_socketio.js
+++ b/test/targets/simple_socketio.js
@@ -10,8 +10,8 @@ var MESSAGE_COUNT = 0;
 var CONNECTION_COUNT = 0;
 var PRINT_NS_CONNECTIONS = false;
 var CONNECTIONS = {
-  nsp1  : {connections: 0, messages: 0},
-  nsp2  : {connections: 0, messages: 0},
+  nsp1: {connections: 0, messages: 0},
+  nsp2: {connections: 0, messages: 0}
 };
 
 
@@ -24,7 +24,7 @@ io.of('/nsp1').on('connection', function connection(ws){
     CONNECTIONS.nsp1.messages++;
     console.log('Socket.io /nsp1 echoing message: %s', message);
     ws.emit('echoed:nsp1', message);
-  })
+  });
 });
 
 io.of('/nsp2').on('connection', function connection(ws){
@@ -35,7 +35,7 @@ io.of('/nsp2').on('connection', function connection(ws){
     CONNECTIONS.nsp2.messages++;
     console.log('Socket.io /nsp2 echoing message: %s', message);
     ws.emit('echoed:nsp2', message);
-  })
+  });
 });
 
 

--- a/test/targets/simple_socketio.js
+++ b/test/targets/simple_socketio.js
@@ -8,23 +8,56 @@ http.listen(PORT, function() {
 
 var MESSAGE_COUNT = 0;
 var CONNECTION_COUNT = 0;
+var PRINT_NS_CONNECTIONS = false;
+var CONNECTIONS = {
+  nsp1  : {connections: 0, messages: 0},
+  nsp2  : {connections: 0, messages: 0},
+};
+
+
+
+io.of('/nsp1').on('connection', function connection(ws){
+  PRINT_NS_CONNECTIONS = true;
+  CONNECTIONS.nsp1.connections++;
+  console.log('+ Socket.io new connection in /nsp1');
+  ws.on('echo', function incoming(message){
+    CONNECTIONS.nsp1.messages++;
+    console.log('Socket.io /nsp1 echoing message: %s', message);
+    ws.emit('echoed:nsp1', message);
+  })
+});
+
+io.of('/nsp2').on('connection', function connection(ws){
+  PRINT_NS_CONNECTIONS = true;
+  CONNECTIONS.nsp2.connections++;
+  console.log('+ Socket.io new connection in /nsp2');
+  ws.on('echo', function incoming(message){
+    CONNECTIONS.nsp2.messages++;
+    console.log('Socket.io /nsp2 echoing message: %s', message);
+    ws.emit('echoed:nsp2', message);
+  })
+});
+
+
 
 io.on('connection', function connection(ws) {
   CONNECTION_COUNT++;
   console.log('+ Socket.io connection');
+
   ws.on('echo', function incoming(message) {
     MESSAGE_COUNT++;
     console.log('Socket.io echoing message: %s', message);
     ws.emit('echoed', message);
   });
-
-
 });
 
 setInterval(function() {
   console.log(new Date());
   console.log('CONNECTION_COUNT [socketio] = %s', CONNECTION_COUNT);
-  console.log('MESSAGE_COUNT    [socketio] = %s', MESSAGE_COUNT);
+  console.log('MESSAGE_COUNT    [socketio] = %s', MESSAGE_COUNT + CONNECTIONS.nsp1.messages + CONNECTIONS.nsp2.messages);
+  if(PRINT_NS_CONNECTIONS) {
+    console.log('CONNECTIONS      [socketio] = %s', JSON.stringify(CONNECTIONS));
+  }
 }, 5 * 1000);
 
 function handler(req, res) {


### PR DESCRIPTION
This change allows socket.IO namespaces to be configured by adding a `namespace` attribute to the `emit` actions.

More info: https://github.com/shoreditch-ops/artillery-core/issues/124