### PR TITLE
HTTP engine fixes

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -81,7 +81,10 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
       return self.step(rs, ee, opts);
     });
 
-    return engineUtil.createLoopWithCount(requestSpec.count || -1, steps);
+    return engineUtil.createLoopWithCount(
+      requestSpec.count || -1,
+      steps,
+      { counterName: requestSpec.loop.counterName || '$loopCount' });
   }
 
   if (requestSpec.think) {

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -37,30 +37,6 @@ HttpEngine.prototype.createScenario = function(scenarioSpec, ee) {
 
   let tasks = _.map(scenarioSpec.flow, function(rs) {
 
-    if (rs.think) {
-      return engineUtil.createThink(rs, _.get(self.config, 'defaults.think', {}));
-    }
-
-    if (rs.log) {
-      return function(context, callback) {
-        console.log(template(rs.log, context));
-        return process.nextTick(function() { callback(null, context); });
-      };
-    }
-
-    if (rs.function) {
-      return function(context, callback) {
-        let processFunc = self.config.processor[rs.function];
-        if (processFunc) {
-          return processFunc(context, ee, function() {
-            return callback(null, context);
-          });
-        } else {
-          return process.nextTick(function () { callback(null, context); });
-        }
-      };
-    }
-
     return self.step(rs, ee, {
       beforeRequest: scenarioSpec.beforeRequest || [],
       afterResponse: scenarioSpec.afterResponse || []
@@ -89,6 +65,26 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
 
   if (requestSpec.think) {
     return engineUtil.createThink(requestSpec, _.get(self.config, 'defaults.think', {}));
+  }
+
+  if (requestSpec.log) {
+    return function(context, callback) {
+      console.log(template(requestSpec.log, context));
+      return process.nextTick(function() { callback(null, context); });
+    };
+  }
+
+  if (requestSpec.function) {
+    return function(context, callback) {
+      let processFunc = self.config.processor[requestSpec.function];
+      if (processFunc) {
+        return processFunc(context, ee, function() {
+          return callback(null, context);
+        });
+      } else {
+        return process.nextTick(function () { callback(null, context); });
+      }
+    };
   }
 
   let f = function(context, callback) {

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -53,14 +53,17 @@ function createThink(requestSpec, opts) {
 
 // "count" can be an integer (negative or positive) or a string defining a range
 // like "1-15"
-function createLoopWithCount(count, steps) {
+function createLoopWithCount(count, steps, opts) {
   let from = parseLoopCount(count).from;
   let to = parseLoopCount(count).to;
+
 
   return function aLoop(context, callback) {
     let i = from;
     let newContext = context;
-    newContext.vars.$loopCount = i;
+    let loopIndexVar = (opts && opts.counterName) || '$loopCount';
+
+    newContext.vars[loopIndexVar] = i;
     A.whilst(
       function test() {
         return i < to || to === -1;
@@ -73,7 +76,7 @@ function createLoopWithCount(count, steps) {
         A.waterfall(steps2, function(err, context2) {
           i++;
           newContext = context2;
-          newContext.vars.$loopCount++;
+          newContext.vars[loopIndexVar]++;
           return cb(err, context2);
         });
       },

--- a/package.json
+++ b/package.json
@@ -43,15 +43,16 @@
     "bcrypt": "^0.8.5",
     "csv-parse": "1.0.1",
     "eslint": "^0.24.0",
+    "express": "4.13.4",
     "good": "6.4.0",
     "good-console": "5.1.0",
     "hapi": "10.4.0",
     "hapi-auth-basic": "4.1.0",
     "istanbul": "^0.3.17",
     "pre-commit": "^1.0.10",
-    "tape": "^4.0.0",
+    "sinon": "1.17.6",
     "socket.io": "1.4.6",
-    "express": "4.13.4"
+    "tape": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/unit/engine_http.test.js
+++ b/test/unit/engine_http.test.js
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const test = require('tape');
+const sinon = require('sinon');
+const HttpEngine = require('../../lib/engine_http');
+const EventEmitter = require('events');
+
+const THINKTIME_SEC = 1;
+
+const script = {
+  config: {
+    target: 'http://localhost:8888',
+    processor: {
+      f: function(context, ee, next) {
+        context.vars.newVar = 1234;
+        return next();
+      },
+
+      inc: function(context, ee, next) {
+        context.vars.inc = context.vars.$loopCount;
+        return next();
+      }
+    }
+  },
+  scenarios: [
+    {
+      name: 'Whatever',
+      flow: [
+        { think: THINKTIME_SEC },
+        { function: 'f' },
+        { log: 'This is printed from the script with "log": {{ newVar }}' },
+        { loop: [
+          { function: 'inc' },
+          { think: 1 }
+        ], count: 3 }
+      ]
+    }
+  ]
+};
+
+test('HTTP engine interface', function(t) {
+  const engine = new HttpEngine(script);
+  const ee = new EventEmitter();
+  const runScenario = engine.createScenario(script.scenarios[0], ee);
+
+  t.assert(engine, 'Can construct an engine');
+  t.assert(typeof runScenario === 'function', 'Can use the engine to create virtual user functions');
+  t.end();
+});
+
+test('HTTP virtual user', function(t) {
+  const engine = new HttpEngine(script);
+  const ee = new EventEmitter();
+  const spy = sinon.spy(console, 'log');
+  const runScenario = engine.createScenario(script.scenarios[0], ee);
+
+  ee.once('started', onStarted);
+
+  const initialContext = {
+    vars: {}
+  };
+
+  t.plan(6);
+
+  const startedAt = Date.now();
+  runScenario(initialContext, function userDone(err, finalContext) {
+    const finishedAt = Date.now();
+    t.assert(!err, 'Virtual user finished successfully');
+    t.assert(finalContext.vars.newVar === 1234, 'Function spec was executed');
+    t.assert(finishedAt - startedAt >= THINKTIME_SEC * 1000, 'User spent some time thinking');
+
+    const expectedLog = 'This is printed from the script with "log": 1234';
+    let seen = false;
+    spy.args.forEach(function(args) {
+      if (args[0] === expectedLog) {
+        t.comment(`string: "${args[0]}" found`);
+        seen = true;
+      }
+    });
+    t.assert(seen, 'log worked');
+
+    // loop count starts at 0, hence 2 rather than 3 here:
+    t.assert(finalContext.vars.inc === 2, 'Function called in a loop');
+  });
+
+  function onStarted() {
+    t.assert(true, 'started event emitted');
+  }
+});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -6,3 +6,4 @@ require('./templates.test.js');
 require('./phases.test.js');
 require('./readers.test.js');
 require('./util.test.js');
+require('./engine_http.test.js');


### PR DESCRIPTION
- Fixes shoreditch-ops/artillery#216
- The name of the variable holding current loop index can be customized with `loop.counterName` (experimental)
- Add tests for the HTTP engine