### PR TITLE
Allow err.code or err.message in beforeRequest

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -207,8 +207,9 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
       function done(err) {
         if (err) {
           debug(err);
+          let errCode = err.code || err.message;
           // FIXME: Should not need to have to emit manually here
-          ee.emit('error', err.code);
+          ee.emit('error', errCode);
           return callback(err, context);
         }
 


### PR DESCRIPTION
In a "beforeRequest" handler if you used a callback such as:

    next(new Error("Some message..."));
    return;

The error message is undefined on the other end and you end up with `undefined` and a count in the error reporting output.

This change fixes that to show the message and uses similar code to the other handling in the file.