### PR TITLE
Add flag handling for regex capture

### DIFF
--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -345,13 +345,19 @@ function extractJSONPath(doc, expr) {
 // doc is a string or an object (body parsed by Request when headers indicate JSON)
 function extractRegExp(doc, expr, opts) {
   let group = opts.group;
+  let flags = opts.flags;
   let str;
   if (typeof doc === 'string') {
     str = doc;
   } else {
     str = JSON.stringify(doc); // FIXME: not the same string as the one we got from the server
   }
-  let rx = new RegExp(expr);
+  let rx;
+  if (flags) {
+      rx = new RegExp(expr, flags);
+  } else {
+      rx = new RegExp(expr);
+  }
   let match = rx.exec(str);
   if(group && match[group]) {
     return match[group];


### PR DESCRIPTION
Allow passing flags such as "i", "g", "m", etc. to regex construction using options similar to "group".