### PR TITLE
Modify when lantency is calculated.

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -311,20 +311,20 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
             });
         }
 
+        var startedAt = null;
+        var code = null;
         request(requestParams, requestCallback)
           .on('request', function(req) {
             ee.emit('request');
-
-            const startedAt = process.hrtime();
-
+            startedAt = process.hrtime();
             req.on('response', function updateLatency(res) {
-              let code = res.statusCode;
+              code = res.statusCode;
+            });
+          }).on('end', function(){ 
               const endedAt = process.hrtime(startedAt);
               let delta = (endedAt[0] * 1e9) + endedAt[1];
               ee.emit('response', delta, code, context._uid);
             });
-          }).on('end', function() {
-          });
       }); // eachSeries
   };
 


### PR DESCRIPTION
In testing artillery we discovered that the reported latency times were inaccurate due to their being calculated at the time of initial response, not taking into account the streaming of the body of the response. For example, if a GET API call takes 2 seconds due to the size of the body, Artillery would only report the time for the initial response code to arrive. 

I can see the rational for the original behavior in that it does as closely approximate the duration of the API call from the server side, but does not reflect the client-side experience.

This PR just changes the behavior to include the full request round trip, but if we don't want to make this change (it's a bit drastic), maybe I can modify it to have a feature toggle. All comments and suggestions are welcome!