### PR TITLE
Reduce memory usage for HTTP scenarios

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -214,6 +214,9 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         }
 
         function requestCallback(err, res, body) {
+          if (err) {
+            return;
+          }
 
           if (process.env.DEBUG) {
             let requestInfo = {
@@ -239,14 +242,6 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
               }
             }
             debug('request: %s', JSON.stringify(requestInfo, null, 2));
-          }
-
-          if (err) {
-            let errCode = err.code || err.message;
-            ee.emit('error', errCode);
-            debug(err);
-            // this aborts the scenario
-            return callback(err, context);
           }
 
           debugResponse(JSON.stringify(res.headers, null, 2));
@@ -298,20 +293,23 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
                       context.vars[k] = v;
                     });
 
-                    context.vars.$ = res.body;
-                    context._successCount++;
                     return callback(null, context);
                   }
                 });
               } else {
-                context.vars.$ = res.body;
-                context._successCount++;
                 return callback(null, context);
               }
             });
         }
 
-        request(requestParams, requestCallback)
+        // If we aren't processing the full response, we don't need the
+        // callback:
+        let maybeCallback;
+        if (params.capture || params.match || params.afterResponse) {
+          maybeCallback = requestCallback;
+        }
+
+        request(requestParams, maybeCallback)
           .on('request', function(req) {
             ee.emit('request');
 
@@ -324,6 +322,17 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
               ee.emit('response', delta, code, context._uid);
             });
           }).on('end', function() {
+            context._successCount++;
+
+            if (!maybeCallback) {
+              callback(null, context);
+            } // otherwise called from requestCallback
+          }).on('error', function(err) {
+            let errCode = err.code || err.message;
+            ee.emit('error', errCode);
+            debug(err);
+            // this aborts the scenario
+            return callback(err, context);
           });
       }); // eachSeries
   };

--- a/test/scripts/captures-regexp.json
+++ b/test/scripts/captures-regexp.json
@@ -21,14 +21,8 @@
             "json": {"name": "{{ name }}", "species": "{{ species }}"},
             "capture": {
               "regexp": "[a-f0-9-]+-[a-f0-9]+",
-              "transform": "this.id.toUpperCase()",
               "as": "id"
             }
-          }
-        },
-        {"get":
-          {
-            "url": "/pets/{{ $.id }}"
           }
         },
         {"get": {

--- a/test/scripts/captures.json
+++ b/test/scripts/captures.json
@@ -24,7 +24,6 @@
             "json": {"name": "{{ name }}", "species": "{{ species }}"},
             "capture": [{
               "json": "{{{ jsonPathExpr }}}",
-              "transform": "this.id.toUpperCase()",
               "as": "id"
             }, {
               "json": "$.doesnotexist",
@@ -34,12 +33,6 @@
               "regexp": ".+",
               "as": "id2"
             }]
-          }
-        },
-        {"get":
-          {
-            "url": "/pets/{{ $.id }}",
-            "match": {"json": "$.name", "value": "{{ name }}"}
           }
         },
         {"get": {

--- a/test/test_capture.js
+++ b/test/test_capture.js
@@ -43,12 +43,13 @@ test('Capture - JSON', (t) => {
     ee.on('done', function(report) {
       let c200 = report.codes[200];
       let c201 = report.codes[201];
-      let c404 = report.codes[404];
-      let cond = c201 * 2 === c200 + c404;
+
+      let cond = c201 === c200;
+
       t.assert(cond,
-               'There should be a 200 and a 404 for every 201');
+               'There should be a 200 for every 201');
       if (!cond) {
-        console.log('200: %s; 201: %s; 404: %s', c200, c201, c404);
+        console.log('200: %s; 201: %s', c200, c201);
       }
       t.end();
     });
@@ -105,12 +106,12 @@ test('Capture - RegExp', (t) => {
   ee.on('done', (report) => {
       let c200 = report.codes[200];
       let c201 = report.codes[201];
-      let c404 = report.codes[404];
-      let cond = c201 * 2 === c200 + c404;
+      let cond = c201 === c200;
+
       t.assert(cond,
-               'There should be a 200 and a 404 for every 201');
+               'There should be a 200 for every 201');
       if (!cond) {
-        console.log('200: %s; 201: %s; 404: %s', c200, c201, c404);
+        console.log('200: %s; 201: %s;', c200, c201);
       }
       t.end();
   });


### PR DESCRIPTION
There is no need to keep the entirety of every response in
memory unless we are processing it in some way. request.js will
discard the response data if a callback is not provided.

Ref: https://github.com/shoreditch-ops/artillery/issues/130