### PR TITLE
Fix error handling in loops

### DIFF
--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -74,6 +74,9 @@ function createLoopWithCount(count, steps, opts) {
         };
         let steps2 = L.flatten([zero, steps]);
         A.waterfall(steps2, function(err, context2) {
+          if (err) {
+            return cb(err, context2);
+          }
           i++;
           newContext = context2;
           newContext.vars[loopIndexVar]++;


### PR DESCRIPTION
Prevent errors in loop steps (such as an ETIMEDOUT) from crashing
the process.

Ref: https://github.com/shoreditch-ops/artillery/issues/234