### PR TITLE
Rewrite the implemenation of {{ }} and {{{ }}} templates

### DIFF
--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -6,7 +6,6 @@
 
 const async = require('async');
 const debug = require('debug')('engine_util');
-const hogan = require('hogan.js');
 const traverse = require('traverse');
 const esprima = require('esprima');
 const L = require('lodash');
@@ -29,7 +28,8 @@ module.exports = {
   isProbableEnough: isProbableEnough,
   template: template,
   captureOrMatch,
-  evil: evil
+  evil: evil,
+  _renderVariables: renderVariables
 };
 
 function createThink(requestSpec, opts) {
@@ -139,9 +139,28 @@ function template(o, context) {
         return o;
       }
 
-      result = (hogan.compile(o)).render(context.vars);
+      result = renderVariables(o, context.vars);
     }
   }
+  return result;
+}
+
+function renderVariables (str, vars) {
+  const RX = /{{{?[\s$\w]+}}}?/g;
+  let rxmatch;
+  let result = str.substring(0, str.length);
+
+  while (result.search(RX) > -1) {
+    let templateStr = result.match(RX)[0];
+    const varName = templateStr.replace(/{/g, '').replace(/}/g, '').trim();
+
+    let varValue = vars[varName] || '';
+    if (typeof varValue === 'object') {
+      varValue = JSON.stringify(varValue);
+    }
+    result = result.replace(templateStr, varValue);
+  }
+
   return result;
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "deep-equal": "^1.0.1",
     "esprima": "2.5.0",
     "filtrex": "0.5.4",
-    "hogan.js": "^3.0.2",
     "jsck": "0.2.5",
     "lodash": "4.13.1",
     "nanotimer": "0.3.14",

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -61,3 +61,37 @@ test('loop - error handling', function(t) {
     t.end();
   });
 });
+
+test('rendering variables', function(t) {
+  let str = 'Hello {{ name }}, hope your {{{ day }}} is going great!';
+  let vars = {
+    name: 'Hassy',
+    day: 'Friday'
+  };
+
+  t.assert(
+    util._renderVariables(str, vars) === 'Hello Hassy, hope your Friday is going great!',
+    'Variables are substituted with either double or triple curly braces');
+
+  t.assert(
+    util._renderVariables('{{ s }} - {{ s }} {}', { s: 'foo' }) === 'foo - foo {}',
+    'Multiple instances of a variable get replaced');
+
+  t.assert(
+    util._renderVariables(' {{   foo}} ', { foo: 'bar' }) === ' bar ',
+    'Whitespace inside templates is not significant');
+
+  t.assert(
+    util._renderVariables('Hello {{ name }}', { foo: 'bar', day: 'Sunday' }) === 'Hello ',
+    'Undefined variables get replaced with an empty string');
+
+  t.assert(
+    util._renderVariables('', { foo: 'bar', name: 'Hassy', color: 'red' }) === '',
+    'Empty string produces an empty string');
+
+  t.assert(
+    util._renderVariables('Hello world!', { foo: 'bar', name: 'Hassy', color: 'red' }) === 'Hello world!',
+    'String with no templates produces itself');
+
+  t.end();
+});


### PR DESCRIPTION
- Remove hogan.js, replace with a simple regexp find and replace
- {{ }} won't HTML-escape values anymore (i.e. {{}} and {{{}}}
  are now equivalent)