### PR TITLE
Allow configuration of socket.io transports

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -16,6 +16,13 @@ module.exports = SocketIoEngine;
 
 function SocketIoEngine(script) {
   this.config = script.config;
+
+  if (script.config.socketio && script.config.socketio.transports) {
+    this.transports = {
+      transports: script.config.socketio.transports
+    };
+  }
+
   this.httpDelegate = new EngineHttp(script);
 }
 
@@ -207,7 +214,12 @@ SocketIoEngine.prototype.loadContextSocket = function(namespace, context, cb) {
   if(!context.sockets[namespace]) {
     let target = this.config.target + namespace;
     let tls = this.config.tls || {};
-    let options = _.extend({}, tls);
+    let transports = this.transports || {};
+    let options = _.extend(
+      {},
+      tls,
+      transports
+    );
 
     context.sockets[namespace] = io.connect(target, options);
 
@@ -241,7 +253,12 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
   function zero(callback, context) {
     let tls = config.tls || {};
-    let options = _.extend({}, tls);
+    let transports = self.transports || {};
+    let options = _.extend(
+      {},
+      tls,
+      transports
+    );
     let socketio = io.connect(config.target, options);
     socketio.on('connect', function() {
       ee.emit('started');


### PR DESCRIPTION
Hi. I would like to use Artillery to test a socket.io application which doesn't support long polling, which is not possible with current implementation of Artillery. Without specifying that long polling isn't available socket.io tries connecting via long polling and fails.

This pull request allows using following structure in config:

```yml
config:
    transports: ["websocket"]
```

To tell socket.io-client that it should connect only using websockets. When the section is not defined, default values are used.

I'll be happy to adjust the code if necessary.