### PR TITLE
Fix: prevent from crashing when context is null/undefined

### DIFF
--- a/lib/engine_ws.js
+++ b/lib/engine_ws.js
@@ -112,9 +112,11 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
         if (err) {
           debug(err);
         }
-        if (context.ws) {
+
+        if (context && context.ws) {
           context.ws.close();
         }
+
         return callback(err, context);
       });
   };


### PR DESCRIPTION
Ref: https://github.com/shoreditch-ops/artillery/issues/257