### PR TITLE
Fix artillery hang when capture results in no url being produced

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -365,6 +365,11 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           maybeCallback = requestCallback;
         }
 
+        if(!requestParams.url) {
+          ee.emit('error', 'Invalid request url');
+          return callback('Invalid request url', context);
+        }
+
         request(requestParams, maybeCallback)
           .on('request', function(req) {
             ee.emit('request');

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -366,8 +366,9 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         }
 
         if(!requestParams.url) {
-          ee.emit('error', 'Invalid request url');
-          return callback('Invalid request url', context);
+          let err = new Error('an URL must be specified');
+          ee.emit('error', err.message);
+          return callback(err, context);
         }
 
         request(requestParams, maybeCallback)


### PR DESCRIPTION
Addresses issue #151 .
This is especially problematic for people using this with serverless-artillery, as it causes the lambda to timeout instead of terminating correctly.