### PR TITLE
add `init` event so plugins can set variables

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -196,6 +196,8 @@ function run(script, ee, options, runState) {
   let intermediate = Stats.create();
   let aggregate = [];
 
+  ee.emit('init', script, options);
+
   let phaser = createPhaser(script.config.phases);
   phaser.on('arrival', function() {
     runScenario(script, intermediate, runState);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -196,8 +196,6 @@ function run(script, ee, options, runState) {
   let intermediate = Stats.create();
   let aggregate = [];
 
-  ee.emit('init', script, options);
-
   let phaser = createPhaser(script.config.phases);
   phaser.on('arrival', function() {
     runScenario(script, intermediate, runState);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "ws": "1.0.1"
   },
   "devDependencies": {
+    "@package/somePackagedPlugin": "file:test/plugins/packaged_plugin",
+    "artillery-plugin-someAdvancedPlugin": "file:test/plugins/advanced_plugin",
+    "artillery-plugin-someNormalPlugin": "file:test/plugins/normal_plugin",
     "bcrypt": "^0.8.5",
     "csv-parse": "1.0.1",
     "eslint": "^0.24.0",

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,8 @@ require('./test_if');
 require('./ws/test_options');
 require('./test_think');
 require('./test_basic_auth');
+require('./test_config_variables');
+require('./test_config_plugin_package');
 
 //require('./test_worker_http');
 //require('./test_environments.js');

--- a/test/plugins/advanced_plugin/index.js
+++ b/test/plugins/advanced_plugin/index.js
@@ -8,10 +8,8 @@ const assert = require('assert');
 
 function advancedPlugin(config, ee) {
 
-  ee.on('init', function(script, options) {
-    assert(script.config.plugins.someAdvancedPlugin.foo === 'bar');
-    script.config.variables.advanced = 'hello';
-  });
+  assert(config.plugins.someAdvancedPlugin.foo === 'bar');
+  config.variables.advanced = 'hello';
 
   ee.on('done', function(stats){
     ee.emit('plugin_loaded', stats);

--- a/test/plugins/advanced_plugin/index.js
+++ b/test/plugins/advanced_plugin/index.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const assert = require('assert');
+
+function advancedPlugin(config, ee) {
+
+  ee.on('init', function(script, options) {
+    assert(script.config.plugins.someAdvancedPlugin.foo === 'bar');
+    script.config.variables.advanced = 'hello';
+  });
+
+  ee.on('done', function(stats){
+    ee.emit('plugin_loaded', stats);
+  });
+  return this;
+}
+
+module.exports = advancedPlugin;

--- a/test/plugins/advanced_plugin/package.json
+++ b/test/plugins/advanced_plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "artillery-plugin-someAdvancedPlugin",
+  "version": "1.0.0",
+  "description": "Advanced plugin",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "https://github.com/HarryWeppner",
+  "license": "MPL-2.0"
+}

--- a/test/scripts/advanced_plugin.json
+++ b/test/scripts/advanced_plugin.json
@@ -1,0 +1,26 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:3003",
+      "phases": [
+        {"duration": 2, "arrivalRate": 1}
+      ],
+      "plugins": {
+        "someAdvancedPlugin": {
+          "foo": "bar"
+        }
+      },
+      "variables": {}
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {
+          "get": {
+            "beforeRequest": "expectHello",
+            "url": "/"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/test_config_plugin_package.js
+++ b/test/test_config_plugin_package.js
@@ -8,29 +8,43 @@ const test = require('tape');
 const runner = require('../lib/runner').runner;
 
 test('Plugin package name inside plugin config', function(t) {
-    runTest(t, './scripts/plugin_packaged_inner.json');
+  runTest(t, './scripts/plugin_packaged_inner.json');
 });
 
 test('Plugin package name outside plugin config', function(t) {
-    runTest(t, './scripts/plugin_packaged_outer.json');
+  runTest(t, './scripts/plugin_packaged_outer.json');
 });
 
 test('Plugin package name inside plugin config overriding outter package name', function(t) {
-    runTest(t, './scripts/plugin_packaged_inner_override_outter.json');
+  runTest(t, './scripts/plugin_packaged_inner_override_outter.json');
 });
 
 test('Normal artillery-plugin-*', function(t) {
-    runTest(t, './scripts/artillery_plugin.json');
+  runTest(t, './scripts/artillery_plugin.json');
 });
 
-function runTest(t, scriptName){
-    const script = require(scriptName);
-    const ee = runner(script);
+test('Advanced artillery-plugin-*', function(t) {
+  var pluginScript = require('./scripts/advanced_plugin.json');
 
-    ee.on('plugin_loaded', function(stats){
-      t.assert(true);
-      t.end();
-    });
+  pluginScript.config.processor = {
+    "expectHello": function(req, context, ee, next) {
+      t.assert(context.vars.advanced === 'hello');
+      return next();
+    }
+  };
 
-    ee.run();
+  runTest(t, pluginScript);
+});
+
+function runTest(t, scriptRef){
+
+  const script = (typeof scriptRef === 'string') ? require(scriptRef) : scriptRef;
+  const ee = runner(script);
+
+  ee.on('plugin_loaded', function(stats){
+    t.assert(true);
+    t.end();
+  });
+
+  ee.run();
 }


### PR DESCRIPTION
adds an `init` event so plugins can control (set) variables that processor functions can utilize.

The advanced plugin test consists of the following checks:

1) checks that the plugin variable `foo` is set to `bar`
2) checks that the plugin sets the variable `advanced` to `hello`
   (in `expectHello`).

NOTE: the `advanced` variable is set when `init` event occurs.