### PR TITLE
Add socketio path option

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -29,6 +29,12 @@ function SocketIoEngine(script) {
         query: script.config.socketio.query
       }
     }
+
+	if (script.config.socketio.path) {
+      this.path = {
+        path: script.config.socketio.path
+      }
+    }
   }
 
   this.httpDelegate = new EngineHttp(script);
@@ -223,12 +229,14 @@ SocketIoEngine.prototype.loadContextSocket = function(namespace, context, cb) {
     let target = this.config.target + namespace;
     let tls = this.config.tls || {};
     let transports = this.transports || {};
+    let path = this.path || {};
     let query = this.query || {};
     let options = _.extend(
       {},
       tls,
       transports,
-      query
+      query,
+      path
     );
 
     context.sockets[namespace] = io.connect(target, options);
@@ -264,10 +272,12 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
   function zero(callback, context) {
     let tls = config.tls || {};
     let transports = self.transports || {};
+    let path = self.path || {};
     let options = _.extend(
       {},
       tls,
-      transports
+      transports,
+      path
     );
     let socketio = io.connect(config.target, options);
     socketio.on('connect', function() {


### PR DESCRIPTION
Adds the ability to specify a ```path``` parameter for socket.io:

For example:

```yaml
config:
  target: 'http://localhost:3005'
  phases:
    - duration: 5
      arrivalRate: 1
  socketio:
      path: '/ws'

scenarios:
  -
    engine: "socketio"
    flow:
    - emit:
        channel: "subscribe"
        data:
            some: "data"
```