### PR TITLE
fix error caused by connection error in socketio

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -279,9 +279,9 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
       transports,
       path
     );
+    ee.emit('started');
     let socketio = io.connect(config.target, options);
     socketio.on('connect', function() {
-      ee.emit('started');
       return callback(null, _.extend({socketio: socketio}, context));
     });
     socketio.once('connect_error', function(err) {


### PR DESCRIPTION
https://github.com/shoreditch-ops/artillery/issues/238

When SocketIo cannot connect because of high server load, `ee.emit('started')` won't be run.
This will lead to wrong count of scenarios ( negative number of scenarios ) and runner won't terminate.