### PR TITLE
Remove environment resolution

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -82,14 +82,6 @@ function runner(script, payload, options) {
 
   let runnableScript = _.cloneDeep(script);
 
-  if (opts.environment) {
-    debug('environment specified: %s', opts.environment);
-    _.merge(
-      runnableScript.config,
-      script.config.environments[opts.environment]);
-    runnableScript._environment = opts.environment;
-  }
-
   // Flatten flows (can have nested arrays of request specs with YAML references):
   _.each(runnableScript.scenarios, function(scenarioSpec) {
     scenarioSpec.flow = _.flatten(scenarioSpec.flow);


### PR DESCRIPTION
Environment is to be resolved by the CLI or another wrapper. This
allows for payloads for example to be part of an environment
specification.