### PR TITLE
Run afterResponse hooks after capture/match

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -284,60 +284,61 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           debugResponse(JSON.stringify(res.headers, null, 2));
           debugResponse(JSON.stringify(body, null, 2));
 
-          // Run afterResponse processors (scenario-level ones too)
-          let functionNames = _.concat(opts.afterResponse || [], params.afterResponse || []);
-          async.eachSeries(
-            functionNames,
-            function iteratee(functionName, next) {
-              let processFunc = config.processor[functionName];
-              processFunc(requestParams, res, context, ee, function(err) {
-                if (err) {
-                  return next(err);
-                }
-                return next(null);
-              });
-            },
-            function done(err) {
+          engineUtil.captureOrMatch(
+            params,
+            res,
+            context,
+            function captured(err, result) {
               if (err) {
-                debug(err);
-                ee.emit('error', err.code || err.message);
+                // end the scenario
+                ee.emit('error', err.message);
                 return callback(err, context);
               }
-              if (params.capture || params.match) {
-                engineUtil.captureOrMatch(params, res, context, function(err, result) {
+
+              let haveFailedMatches = _.some(result.matches, function(v, k) {
+                return !v.success && v.strict !== false; // strict by default
+              });
+
+              if (haveFailedMatches) {
+                // TODO: Should log the details of the match somewhere
+                ee.emit('error', 'Failed match');
+                return callback(new Error('Failed match'), context);
+              } else {
+                _.each(result.matches, function(v, k) {
+                  ee.emit('match', v.success, {
+                    expected: v.expected,
+                    got: v.got,
+                    expression: v.expression,
+                    strict: v.strict
+                  });
+                });
+
+                _.each(result.captures, function(v, k) {
+                  context.vars[k] = v;
+                });
+              }
+
+              // Now run afterResponse processors
+              let functionNames = _.concat(opts.afterResponse || [], params.afterResponse || []);
+              async.eachSeries(
+                functionNames,
+                function iteratee(functionName, next) {
+                  let processFunc = config.processor[functionName];
+                  processFunc(requestParams, res, context, ee, function(err) {
+                    if (err) {
+                      return next(err);
+                    }
+                    return next(null);
+                  });
+                }, function(err) {
                   if (err) {
-                    // end the scenario
-                    ee.emit('error', err.message);
+                    debug(err);
+                    ee.emit('error', err.code || err.message);
                     return callback(err, context);
                   }
 
-                  let haveFailedMatches = _.some(result.matches, function(v, k) {
-                    return !v.success;
-                  });
-
-                  if (haveFailedMatches) {
-                    // TODO: Should log the details of the match somewhere
-                    ee.emit('error', 'Failed match');
-                    return callback(new Error('Failed match'), context);
-                  } else {
-                    _.each(result.matches, function(v, k) {
-                      ee.emit('match', v.success, {
-                        expected: v.expected,
-                        got: v.got,
-                        expression: v.expression
-                      });
-                    });
-
-                    _.each(result.captures, function(v, k) {
-                      context.vars[k] = v;
-                    });
-
-                    return callback(null, context);
-                  }
+                  return callback(null, context);
                 });
-              } else {
-                return callback(null, context);
-              }
             });
         }
 

--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -27,13 +27,13 @@ function SocketIoEngine(script) {
     if (script.config.socketio.query) {
       this.query = {
         query: script.config.socketio.query
-      }
+      };
     }
 
 	if (script.config.socketio.path) {
       this.path = {
         path: script.config.socketio.path
-      }
+      };
     }
   }
 

--- a/lib/engine_util.js
+++ b/lib/engine_util.js
@@ -207,14 +207,19 @@ function parseLoopCount(countSpec) {
 // {captures: { var: value }, matches: { var: {expected: '', got: ''} }}
 //
 function captureOrMatch(params, response, context, done) {
-  let specs = L.concat(
-    L.get(params, 'capture', []),
-    L.get(params, 'match', []));
-
   let result = {
     captures: {},
     matches: {}
   };
+
+  if (!params.capture && !params.match) {
+    return done(null, result);
+  }
+
+  let specs = L.concat(
+    L.get(params, 'capture', []),
+    L.get(params, 'match', []));
+
 
   async.eachSeries(
     specs,


### PR DESCRIPTION
This gives afterResponse hook functions access to the results of `capture` expressions.