### PR TITLE
Allow for plugins to be loaded asynchronously

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -10,6 +10,7 @@ const _ = require('lodash');
 const debug = require('debug')('runner');
 const debugPerf = require('debug')('perf');
 const uuid = require('uuid');
+const A = require('async');
 const Stats = require('./stats2');
 const JSCK = require('jsck');
 const createPhaser = require('./phases');
@@ -38,7 +39,7 @@ function validate(script) {
   return validation;
 }
 
-function runner(script, payload, options) {
+function runner(script, payload, options, callback) {
   let opts = _.assign({
     periodicStats: script.config.statsInterval || 10,
     mode: script.config.mode || 'uniform'
@@ -163,25 +164,60 @@ function runner(script, payload, options) {
     }
   });
 
-  ee.run = function() {
-    let runState = {
-      pendingScenarios: 0,
-      pendingRequests: 0,
-      compiledScenarios: null,
-      scenarioEvents: null,
-      picker: undefined,
-      plugins: runnerPlugins,
-      engines: runnerEngines
-    };
-    debug('run() with: %j', runnableScript);
-    run(runnableScript, ee, opts, runState);
-  };
+  debug('opts.plugins = ', JSON.stringify(opts.plugins, null, 4));
+  const promise = new Promise(function(resolve, reject) {
+    A.eachSeries(
+      opts.plugins,
+      function iterator(pluginName, next) {
+        let pluginModule = null;
+        try {
+          pluginModule = require(pluginName);
+        } catch (err) {
+          console.log('WARNING: could not load plugin %s', pluginName);
+          console.log(err);
+        }
 
-  // FIXME: Warnings should be returned from this function instead along with
-  // the event emitter. That will be a breaking change.
-  ee.warnings = warnings;
+        if(!pluginModule) {
+          return next(null);
+        }
 
-  return ee;
+        let plugin = new pluginModule.Plugin(runnableScript, ee);
+        // TODO: Keep a reference to all plugins somewhere
+        return next(null, { plugin: pluginName, loaded: true });
+      },
+      function allDone(err) {
+        if (err) {
+          console.log(err);
+        }
+
+        ee.run = function() {
+          let runState = {
+            pendingScenarios: 0,
+            pendingRequests: 0,
+            compiledScenarios: null,
+            scenarioEvents: null,
+            picker: undefined,
+            plugins: runnerPlugins,
+            engines: runnerEngines
+          };
+          debug('run() with: %j', runnableScript);
+          run(runnableScript, ee, opts, runState);
+        };
+
+        // FIXME: Warnings should be returned from this function instead along with
+        // the event emitter. That will be a breaking change.
+        ee.warnings = warnings;
+
+        resolve(ee);
+      });
+  });
+
+  if (callback && typeof callback === 'function') {
+    promise.then(callback.bind(null, null), callback);
+  }
+
+  return promise;
+
 }
 
 function run(script, ee, options, runState) {

--- a/test/test_arrivals.js
+++ b/test/test_arrivals.js
@@ -6,17 +6,17 @@ const runner = require('../lib/runner').runner;
 test('arrival phases', function(t) {
   var script = require('./scripts/arrival_phases.json');
 
-  var ee = runner(script);
+  runner(script).then(function(ee) {
+    ee.on('phaseStarted', function(info) {
+      console.log('Starting phase: %j - %s', info, new Date());
+    });
+    ee.on('phaseCompleted', function() {
+      console.log('Phase completed - %s', new Date());
+    });
 
-  ee.on('phaseStarted', function(info) {
-    console.log('Starting phase: %j - %s', info, new Date());
+    ee.on('done', function(stats) {
+      t.end();
+    });
+    ee.run();
   });
-  ee.on('phaseCompleted', function() {
-    console.log('Phase completed - %s', new Date());
-  });
-
-  ee.on('done', function(stats) {
-    t.end();
-  });
-  ee.run();
 });

--- a/test/test_basic_auth.js
+++ b/test/test_basic_auth.js
@@ -6,15 +6,16 @@ const runner = require('../lib/runner').runner;
 test('HTTP basic auth', (t) => {
   const script = require('./scripts/hello_basic_auth.json');
 
-  let ee = runner(script);
-  ee.on('done', (report) => {
-    let requests = report.requestsCompleted;
-    let code200 = report.codes[200];
-    let code401 = report.codes[401];
-    t.assert(
-      requests > 0 && (code200 === code401 * 2),
-      `Expected twice as many 200s as 401s, got ${code200} 200s and ${code401} 401s`);
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', (report) => {
+      let requests = report.requestsCompleted;
+      let code200 = report.codes[200];
+      let code401 = report.codes[401];
+      t.assert(
+        requests > 0 && (code200 === code401 * 2),
+        `Expected twice as many 200s as 401s, got ${code200} 200s and ${code401} 401s`);
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });

--- a/test/test_capture.js
+++ b/test/test_capture.js
@@ -17,14 +17,15 @@ try {
 test('Capture - headers', (t) => {
   const fn = './scripts/captures-header.json';
   const script = require(fn);
-  let ee = runner(script);
-  ee.on('done', function(report) {
-    // This will fail if header capture isn't working
-    t.assert(!report.codes[403], 'No unauthorized responses');
-    t.assert(report.codes[200] > 0, 'Successful responses');
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      // This will fail if header capture isn't working
+      t.assert(!report.codes[403], 'No unauthorized responses');
+      t.assert(report.codes[200] > 0, 'Successful responses');
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });
 
 
@@ -38,23 +39,24 @@ test('Capture - JSON', (t) => {
       t.fail(err);
     }
 
-    let ee = runner(script, parsedData, {});
+    runner(script, parsedData, {}).then(function(ee) {
 
-    ee.on('done', function(report) {
-      let c200 = report.codes[200];
-      let c201 = report.codes[201];
+      ee.on('done', function(report) {
+        let c200 = report.codes[200];
+        let c201 = report.codes[201];
 
-      let cond = c201 === c200;
+        let cond = c201 === c200;
 
-      t.assert(cond,
-               'There should be a 200 for every 201');
-      if (!cond) {
-        console.log('200: %s; 201: %s', c200, c201);
-      }
-      t.end();
+        t.assert(cond,
+                 'There should be a 200 for every 201');
+        if (!cond) {
+          console.log('200: %s; 201: %s', c200, c201);
+        }
+        t.end();
+      });
+
+      ee.run();
     });
-
-    ee.run();
   });
 });
 
@@ -73,9 +75,25 @@ test('Capture - XML', (t) => {
       t.fail(err);
     }
 
-    let ee = runner(script, parsedData, {});
+    runner(script, parsedData, {}).then(function(ee) {
 
-    ee.on('done', function(report) {
+      ee.on('done', function(report) {
+        t.assert(report.codes[200] > 0, 'Should have a few 200s');
+        t.assert(report.codes[404] === undefined, 'Should have no 404s');
+        t.end();
+      });
+
+      ee.run();
+    });
+  });
+});
+
+test('Capture - Random value from array', (t) => {
+  const fn = './scripts/captures_array_random.json';
+  const script = require(fn);
+  runner(script).then(function(ee) {
+
+    ee.on('done', (report) => {
       t.assert(report.codes[200] > 0, 'Should have a few 200s');
       t.assert(report.codes[404] === undefined, 'Should have no 404s');
       t.end();
@@ -85,25 +103,11 @@ test('Capture - XML', (t) => {
   });
 });
 
-test('Capture - Random value from array', (t) => {
-  const fn = './scripts/captures_array_random.json';
-  const script = require(fn);
-  let ee = runner(script);
-
-  ee.on('done', (report) => {
-    t.assert(report.codes[200] > 0, 'Should have a few 200s');
-    t.assert(report.codes[404] === undefined, 'Should have no 404s');
-    t.end();
-  });
-
-  ee.run();
-});
-
 test('Capture - RegExp', (t) => {
   const fn = './scripts/captures-regexp.json';
   const script = require(fn);
-  let ee = runner(script);
-  ee.on('done', (report) => {
+  let ee = runner(script).then(function(ee) {
+    ee.on('done', (report) => {
       let c200 = report.codes[200];
       let c201 = report.codes[201];
       let cond = c201 === c200;
@@ -114,7 +118,8 @@ test('Capture - RegExp', (t) => {
         console.log('200: %s; 201: %s;', c200, c201);
       }
       t.end();
-  });
+    });
 
-  ee.run();
+    ee.run();
+  });
 });

--- a/test/test_config_plugin_package.js
+++ b/test/test_config_plugin_package.js
@@ -24,8 +24,8 @@ test('Normal artillery-plugin-*', function(t) {
 });
 
 function runTest(t, scriptName){
-    const script = require(scriptName);
-    const ee = runner(script);
+  const script = require(scriptName);
+  runner(script).then(function(ee) {
 
     ee.on('plugin_loaded', function(stats){
       t.assert(true);
@@ -33,4 +33,5 @@ function runTest(t, scriptName){
     });
 
     ee.run();
+  });
 }

--- a/test/test_config_variables.js
+++ b/test/test_config_variables.js
@@ -5,11 +5,12 @@ const runner = require('../lib/runner').runner;
 
 test('config variables', function(t) {
   const script = require('./scripts/config_variables.json');
-  const ee = runner(script);
-  ee.on('done', function(report) {
-    t.assert(report.codes[200] > 0, 'there are 200s for /');
-    t.assert(report.codes[404] > 0, 'there are 404s for /will/404');
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      t.assert(report.codes[200] > 0, 'there are 200s for /');
+      t.assert(report.codes[404] > 0, 'there are 404s for /will/404');
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });

--- a/test/test_cookies.js
+++ b/test/test_cookies.js
@@ -7,53 +7,57 @@ var request = require('request');
 
 test('cookie jar', function(t) {
   var script = require('./scripts/cookies.json');
-  var ee = runner(script);
-  ee.on('done', function(report) {
-    request({
-      method: 'GET',
-      url: 'http://127.0.0.1:3003/_stats',
-      json: true
-    },
-    function(err, res, body) {
-      if (err) {
-        return t.fail();
-      }
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      request(
+        {
+          method: 'GET',
+          url: 'http://127.0.0.1:3003/_stats',
+          json: true
+        },
+        function(err, res, body) {
+          if (err) {
+            return t.fail();
+          }
 
-      var ok = l.size(body.cookies) >= report.scenariosCompleted;
-      t.assert(ok, 'Each scenario had a unique cookie');
-      if (!ok) {
-        console.log(body);
-        console.log(report);
-      }
-      t.end();
+          var ok = l.size(body.cookies) >= report.scenariosCompleted;
+          t.assert(ok, 'Each scenario had a unique cookie');
+          if (!ok) {
+            console.log(body);
+            console.log(report);
+          }
+          t.end();
+        });
     });
+    ee.run();
   });
-  ee.run();
 });
 
 test('default cookies', function(t) {
   var script = require('./scripts/defaults_cookies.json');
-  var ee = runner(script);
-  ee.on('done', function(report) {
-    t.assert(report.codes[200] && report.codes[200] > 0,
-      'There should be some 200s');
-    t.assert(report.codes[403] === undefined,
-      'There should be no 403s');
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      t.assert(report.codes[200] && report.codes[200] > 0,
+               'There should be some 200s');
+      t.assert(report.codes[403] === undefined,
+               'There should be no 403s');
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });
 
 test('no default cookie', function(t) {
   var script = require('./scripts/defaults_cookies.json');
   delete script.config.defaults.cookie;
-  var ee = runner(script);
-  ee.on('done', function(report) {
-    t.assert(report.codes[403] && report.codes[403] > 0,
-      'There should be some 403s');
-    t.assert(report.codes[200] === undefined,
-      'There should be no 200s');
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      t.assert(report.codes[403] && report.codes[403] > 0,
+               'There should be some 403s');
+      t.assert(report.codes[200] === undefined,
+               'There should be no 200s');
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });

--- a/test/test_environments.js
+++ b/test/test_environments.js
@@ -7,17 +7,18 @@ var url = require('url');
 
 test('environments - override target', function(t) {
   var script = require('./scripts/hello_environments.json');
-  var ee = runner(script, null, {environment: 'production'});
-  ee.on('done', function(report) {
-    t.assert(report.requestsCompleted === 0,
-      'there should be no completed requests');
-    t.assert(
-      report.errors.ETIMEDOUT &&
-      report.errors.ETIMEDOUT > 1,
-      'there should ETIMEDOUT errors');
-    t.end();
+  runner(script, null, {environment: 'production'}).then(function(ee) {
+    ee.on('done', function(report) {
+      t.assert(report.requestsCompleted === 0,
+               'there should be no completed requests');
+      t.assert(
+        report.errors.ETIMEDOUT &&
+          report.errors.ETIMEDOUT > 1,
+        'there should ETIMEDOUT errors');
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });
 
 test('environments - override target and phases', function(t) {
@@ -27,16 +28,17 @@ test('environments - override target and phases', function(t) {
     script.config.environments.staging);
   target.listen(
     url.parse(script.config.environments.staging.target).port || 80);
-  var ee = runner(script, null, {environment: 'staging'});
-  ee.on('done', function(report) {
-    var completedAt = process.hrtime(startedAt);
-    var delta = ((completedAt[0] * 1e9) + completedAt[1]) / 1e6;
+  runner(script, null, {environment: 'staging'}).then(function(ee) {
+    ee.on('done', function(report) {
+      var completedAt = process.hrtime(startedAt);
+      var delta = ((completedAt[0] * 1e9) + completedAt[1]) / 1e6;
 
-    t.assert(report.codes[200], 'stats should not be empty');
-    t.assert(delta >= 20 * 1000, 'should\'ve run for 20 seconds');
-    target.stop();
-    t.end();
+      t.assert(report.codes[200], 'stats should not be empty');
+      t.assert(delta >= 20 * 1000, 'should\'ve run for 20 seconds');
+      target.stop();
+      t.end();
+    });
+    startedAt = process.hrtime();
+    ee.run();
   });
-  startedAt = process.hrtime();
-  ee.run();
 });

--- a/test/test_if.js
+++ b/test/test_if.js
@@ -7,18 +7,19 @@ const L = require('lodash');
 test('ifTrue', (t) => {
   const script = require('./scripts/iftrue.json');
 
-  let ee = runner(script);
-  ee.on('done', (report) => {
-    let requests = report.codes[201];
-    let expected = 10;
-    t.assert(
-      requests === expected,
-      'Should have ' + expected + ' 201s (pet created)');
-    t.assert(report.codes[404] === expected,
-             'Should have ' + expected + '404s');
-    t.assert(!report.codes[200],
-             'Should not have 200s');
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', (report) => {
+      let requests = report.codes[201];
+      let expected = 10;
+      t.assert(
+        requests === expected,
+        'Should have ' + expected + ' 201s (pet created)');
+      t.assert(report.codes[404] === expected,
+               'Should have ' + expected + '404s');
+      t.assert(!report.codes[200],
+               'Should not have 200s');
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });

--- a/test/test_loop.js
+++ b/test/test_loop.js
@@ -7,41 +7,43 @@ const L = require('lodash');
 test('simple loop', (t) => {
   const script = require('./scripts/loop.json');
 
-  let ee = runner(script);
-  ee.on('done', (report) => {
-    let scenarios = report.scenariosCompleted;
-    let requests = report.requestsCompleted;
-    let loopCount = script.scenarios[0].flow[0].count;
-    let expected = scenarios * loopCount * 2;
-    t.assert(
-      requests === expected,
-      'Should have ' + expected + ' requests for each completed scenario');
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', (report) => {
+      let scenarios = report.scenariosCompleted;
+      let requests = report.requestsCompleted;
+      let loopCount = script.scenarios[0].flow[0].count;
+      let expected = scenarios * loopCount * 2;
+      t.assert(
+        requests === expected,
+        'Should have ' + expected + ' requests for each completed scenario');
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });
 
 test('loop with range', (t) => {
   const script = require('./scripts/loop_range.json');
 
-  let ee = runner(script);
-  ee.on('done', (report) => {
-    let scenarios = report.scenariosCompleted;
-    let requests = report.requestsCompleted;
-    let expected = scenarios * 3 * 2;
-    let code200 = report.codes[200];
-    let code404 = report.codes[404];
+  runner(script).then(function(ee) {
+    ee.on('done', (report) => {
+      let scenarios = report.scenariosCompleted;
+      let requests = report.requestsCompleted;
+      let expected = scenarios * 3 * 2;
+      let code200 = report.codes[200];
+      let code404 = report.codes[404];
 
-    t.assert(
-      requests === expected,
-      'Should have ' + expected + ' requests for each completed scenario');
-    t.assert(code200 > 0,
-             'There should be a non-zero number of 200s');
+      t.assert(
+        requests === expected,
+        'Should have ' + expected + ' requests for each completed scenario');
+      t.assert(code200 > 0,
+               'There should be a non-zero number of 200s');
 
-    // If $loopCount breaks, we'll see 404s here.
-    t.assert(!code404,
-             'There should be no 404s');
-    t.end();
+      // If $loopCount breaks, we'll see 404s here.
+      t.assert(!code404,
+               'There should be no 404s');
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });

--- a/test/test_misc.js
+++ b/test/test_misc.js
@@ -23,38 +23,39 @@ l.each(SCRIPTS, function(fn) {
     var completedPhases = 0;
     var startedAt = process.hrtime();
 
-    var ee = runner(script);
-    ee.on('phaseStarted', function(x) {
-      t.ok(x, 'phaseStarted event emitted');
-    });
-    ee.on('phaseCompleted', function(x) {
-      completedPhases++;
-      t.ok(x, 'phaseCompleted event emitted');
-    });
-    ee.on('stats', function(stats) {
-      t.ok(stats, 'intermediate stats event emitted');
-    });
-    ee.on('done', function(report) {
-      var requests = report.requestsCompleted;
-      var scenarios = report.scenariosCompleted;
-      console.log('requests = %s, scenarios = %s', requests, scenarios);
+    runner(script).then(function(ee) {
+      ee.on('phaseStarted', function(x) {
+        t.ok(x, 'phaseStarted event emitted');
+      });
+      ee.on('phaseCompleted', function(x) {
+        completedPhases++;
+        t.ok(x, 'phaseCompleted event emitted');
+      });
+      ee.on('stats', function(stats) {
+        t.ok(stats, 'intermediate stats event emitted');
+      });
+      ee.on('done', function(report) {
+        var requests = report.requestsCompleted;
+        var scenarios = report.scenariosCompleted;
+        console.log('requests = %s, scenarios = %s', requests, scenarios);
 
-      t.assert(completedPhases === script.config.phases.length,
-        'Should\'ve completed all phases');
-      var completedAt = process.hrtime(startedAt);
-      var delta = ((completedAt[0] * 1e9) + completedAt[1]) / 1e6;
-      var minDuration = l.reduce(script.config.phases, function(acc, phaseSpec) {
-        return acc + (phaseSpec.duration * 1000);
-      }, 0);
-      t.assert(delta >= minDuration,
-        'Should run for at least the total duration of phases');
+        t.assert(completedPhases === script.config.phases.length,
+                 'Should\'ve completed all phases');
+        var completedAt = process.hrtime(startedAt);
+        var delta = ((completedAt[0] * 1e9) + completedAt[1]) / 1e6;
+        var minDuration = l.reduce(script.config.phases, function(acc, phaseSpec) {
+          return acc + (phaseSpec.duration * 1000);
+        }, 0);
+        t.assert(delta >= minDuration,
+                 'Should run for at least the total duration of phases');
 
-      t.assert(requests > 0, 'Should have successful requests');
-      t.assert(scenarios > 0, 'Should have successful scenarios');
+        t.assert(requests > 0, 'Should have successful requests');
+        t.assert(scenarios > 0, 'Should have successful scenarios');
 
-      t.end();
+        t.end();
+      });
+
+      ee.run();
     });
-
-    ee.run();
   });
 });

--- a/test/test_multiple_payloads.js
+++ b/test/test_multiple_payloads.js
@@ -19,29 +19,30 @@ test('single payload', function(t) {
       t.fail(err);
     }
 
-    let ee = runner(script, parsedData, {});
+    runner(script, parsedData, {}).then(function(ee) {
 
-    ee.on('phaseStarted', function(x) {
-      t.ok(x, 'phaseStarted event emitted');
+      ee.on('phaseStarted', function(x) {
+        t.ok(x, 'phaseStarted event emitted');
+      });
+
+      ee.on('phaseCompleted', function(x) {
+        t.ok(x, 'phaseCompleted event emitted');
+      });
+
+      ee.on('stats', function(stats) {
+        t.ok(stats, 'intermediate stats event emitted');
+      });
+
+      ee.on('done', function(report) {
+        let requests = report.requestsCompleted;
+        let scenarios = report.scenariosCompleted;
+        t.assert(report.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
+        t.assert(report.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
+        t.end();
+      });
+
+      ee.run();
     });
-
-    ee.on('phaseCompleted', function(x) {
-      t.ok(x, 'phaseCompleted event emitted');
-    });
-
-    ee.on('stats', function(stats) {
-      t.ok(stats, 'intermediate stats event emitted');
-    });
-
-    ee.on('done', function(report) {
-      let requests = report.requestsCompleted;
-      let scenarios = report.scenariosCompleted;
-      t.assert(report.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
-      t.assert(report.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
-      t.end();
-    });
-
-    ee.run();
   });
 });
 
@@ -69,29 +70,30 @@ test('multiple_payloads', function(t) {
         t.fail(err);
       }
 
-      let ee = runner(script, script.config.payload, {});
+      runner(script, script.config.payload, {}).then(function(ee) {
 
-      ee.on('phaseStarted', function(x) {
-        t.ok(x, 'phaseStarted event emitted');
+        ee.on('phaseStarted', function(x) {
+          t.ok(x, 'phaseStarted event emitted');
+        });
+
+        ee.on('phaseCompleted', function(x) {
+          t.ok(x, 'phaseCompleted event emitted');
+        });
+
+        ee.on('stats', function(stats) {
+          t.ok(stats, 'intermediate stats event emitted');
+        });
+
+        ee.on('done', function(report) {
+          let requests = report.requestsCompleted;
+          let scenarios = report.scenariosCompleted;
+          t.assert(report.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
+          t.assert(report.codes[200] > 0, 'There are some 200s (URLs constructed from urls.csv)');
+          t.assert(report.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
+          t.end();
+        });
+
+        ee.run();
       });
-
-      ee.on('phaseCompleted', function(x) {
-        t.ok(x, 'phaseCompleted event emitted');
-      });
-
-      ee.on('stats', function(stats) {
-        t.ok(stats, 'intermediate stats event emitted');
-      });
-
-      ee.on('done', function(report) {
-        let requests = report.requestsCompleted;
-        let scenarios = report.scenariosCompleted;
-        t.assert(report.codes[404] > 0, 'There are some 404s (URLs constructed from pets.csv)');
-        t.assert(report.codes[200] > 0, 'There are some 200s (URLs constructed from urls.csv)');
-        t.assert(report.codes[201] > 0, 'There are some 201s (POST with valid data from pets.csv)');
-        t.end();
-      });
-
-      ee.run();
     });
 });

--- a/test/test_probability.js
+++ b/test/test_probability.js
@@ -7,12 +7,13 @@ const L = require('lodash');
 test('request probability', (t) => {
   const script = require('./scripts/probability.json');
 
-  let ee = runner(script);
-  ee.on('done', (report) => {
-    let requests = report.requestsCompleted;
-    t.assert(requests < 130,
-             'Should have completed ~10% = ~100 requests in total, actually completed ' + requests);
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', (report) => {
+      let requests = report.requestsCompleted;
+      t.assert(requests < 130,
+               'Should have completed ~10% = ~100 requests in total, actually completed ' + requests);
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });

--- a/test/test_reuse.js
+++ b/test/test_reuse.js
@@ -5,90 +5,92 @@ var runner = require('../lib/runner').runner;
 
 test('reuse', function(t) {
   let script = require('./scripts/hello.json');
-  let ee = runner(script);
-  let first = true;
-  let expected = 0;
-  let weightedFlowLengths = 0;
-  let lastLatency = null;
-  let intermediate = [];
-  for (let i = 0; i < script.config.phases.length; i++) {
-    let arrivalRate = script.config.phases[0].arrivalRate;
-    let duration = script.config.phases[0].duration;
-    expected += arrivalRate * duration;
-  }
-  for (let i = 0; i < script.scenarios.length; i++) {
-    let flowLength = script.scenarios[i].flow.length;
-    if (script.scenarios[i].weight) {
-      let scenarioWeight = script.scenarios[i].weight;
-      weightedFlowLengths += scenarioWeight * flowLength;
-    } else {
-      weightedFlowLengths += flowLength;
+  runner(script).then(function(ee) {
+    let first = true;
+    let expected = 0;
+    let weightedFlowLengths = 0;
+    let lastLatency = null;
+    let intermediate = [];
+    for (let i = 0; i < script.config.phases.length; i++) {
+      let arrivalRate = script.config.phases[0].arrivalRate;
+      let duration = script.config.phases[0].duration;
+      expected += arrivalRate * duration;
     }
-  }
-  expected *= weightedFlowLengths;
-  ee.on('stats', function(stats) {
-    intermediate.push(stats.report());
-  });
-  ee.on('done', function(report) {
-    let total = 0;
-    for (let i = 0; i < intermediate.length; i++) {
-      total += intermediate[i].latencies.length;
-      t.assert(
+    for (let i = 0; i < script.scenarios.length; i++) {
+      let flowLength = script.scenarios[i].flow.length;
+      if (script.scenarios[i].weight) {
+        let scenarioWeight = script.scenarios[i].weight;
+        weightedFlowLengths += scenarioWeight * flowLength;
+      } else {
+        weightedFlowLengths += flowLength;
+      }
+    }
+    expected *= weightedFlowLengths;
+    ee.on('stats', function(stats) {
+      intermediate.push(stats.report());
+    });
+    ee.on('done', function(report) {
+      let total = 0;
+      for (let i = 0; i < intermediate.length; i++) {
+        total += intermediate[i].latencies.length;
+        t.assert(
           'intermediate should have the same or fewer results',
           intermediate[i].latencies.length <= expected
-      );
-    }
-    t.assert(
+        );
+      }
+      t.assert(
         'total of intermediates should have the same or fewer results',
         total <= expected
-    );
-    t.assert(
+      );
+      t.assert(
         'aggregate should have the expected number of latencies',
         report.latencies.length === expected
-    );
-    if (first) {
-      let last = report.latencies.length - 1;
-      first = false;
-      lastLatency = report.latencies[last][0];
-      ee.run();
-    } else {
-      t.assert(
-          'first latency of second aggregate should be after ' +
-          'the last latency of the first aggregate',
-          lastLatency <= report.latencies[0][0]
       );
-      t.end();
-    }
+      if (first) {
+        let last = report.latencies.length - 1;
+        first = false;
+        lastLatency = report.latencies[last][0];
+        ee.run();
+      } else {
+        t.assert(
+          'first latency of second aggregate should be after ' +
+            'the last latency of the first aggregate',
+          lastLatency <= report.latencies[0][0]
+        );
+        t.end();
+      }
+    });
+    ee.run();
   });
-  ee.run();
 });
 
 test('concurrent runners', function(t) {
   let script = require('./scripts/hello.json');
-  let ee1 = runner(script);
-  let ee2 = runner(script);
+  runner(script).then(function(ee1) {
+    runner(script).then(function(ee2) {
+      let done = 0;
 
-  let done = 0;
+      ee1.on('done', function(report) {
+        console.log('HTTP 200 count:', report.codes[200]);
+        t.assert(report.codes[200] <= 20,
+                 'Stats from the other runner don\'t get merged in');
+        done++;
+        if (done === 2) {
+          t.end();
+        }
+      });
 
-  ee1.on('done', function(report) {
-    console.log('HTTP 200 count:', report.codes[200]);
-    t.assert(report.codes[200] <= 20,
-             'Stats from the other runner don\'t get merged in');
-    done++;
-    if (done === 2) {
-      t.end();
-    }
+      ee2.on('done', function(report) {
+        t.assert(report.codes[200] <= 20,
+                 'Stats from the other runner don\'t get merged in');
+        done++;
+        if (done === 2) {
+          t.end();
+        }
+      });
+
+      ee1.run();
+      ee2.run();
+    });
   });
-
-  ee2.on('done', function(report) {
-    t.assert(report.codes[200] <= 20,
-             'Stats from the other runner don\'t get merged in');
-    done++;
-    if (done === 2) {
-      t.end();
-    }
-  });
-
-  ee1.run();
-  ee2.run();
 });

--- a/test/test_think.js
+++ b/test/test_think.js
@@ -5,10 +5,11 @@ var runner = require('../lib/runner').runner;
 
 test('think', function(t) {
   var script = require('./scripts/thinks_http.json');
-  var ee = runner(script);
-  ee.on('done', function(report) {
-    t.assert('stats should be empty', report.codes === {});
-    t.end();
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      t.assert('stats should be empty', report.codes === {});
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });

--- a/test/test_tls.js
+++ b/test/test_tls.js
@@ -18,28 +18,30 @@ server.listen(3002);
 
 test('tls strict', function(t) {
   var script = require('./scripts/tls-strict.json');
-  var ee = runner(script);
-  ee.on('done', function(report) {
-    var rejected = report.errors.DEPTH_ZERO_SELF_SIGNED_CERT;
-    t.assert(rejected, 'requests to self-signed tls certs fail by default');
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      var rejected = report.errors.DEPTH_ZERO_SELF_SIGNED_CERT;
+      t.assert(rejected, 'requests to self-signed tls certs fail by default');
 
-    t.end();
+      t.end();
+    });
+    ee.run();
   });
-  ee.run();
 });
 
 test('tls lax', function(t) {
   var script = require('./scripts/tls-lax.json');
-  var ee = runner(script);
-  ee.on('done', function(report) {
-    var rejected = report.errors.DEPTH_ZERO_SELF_SIGNED_CERT;
-    var reason = 'requests to self-signed tls certs pass ' +
-                 'when `rejectUnauthorized` is false';
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      var rejected = report.errors.DEPTH_ZERO_SELF_SIGNED_CERT;
+      var reason = 'requests to self-signed tls certs pass ' +
+          'when `rejectUnauthorized` is false';
 
-    t.assert(rejected == null, reason);
+      t.assert(rejected == null, reason);
 
-    t.end();
-    server.close();
+      t.end();
+      server.close();
+    });
+    ee.run();
   });
-  ee.run();
 });

--- a/test/ws/test_options.js
+++ b/test/ws/test_options.js
@@ -10,22 +10,23 @@ const vuserLauncher = require('../../lib/runner').runner;
 
 test('TLS options for WebSocket', function(t) {
   const script = require('./scripts/extra_options.json');
-  const sessions = vuserLauncher(script);
-  sessions.on('done', function(report) {
-    t.assert(Object.keys(report.errors).length === 0,
-             'Test ran without errors');
+  vuserLauncher(script).then(function(sessions) {
+    sessions.on('done', function(report) {
+      t.assert(Object.keys(report.errors).length === 0,
+               'Test ran without errors');
 
-    // Now remove TLS options and rerun - should have an error
-    delete script.config.ws;
-    const sessions2 = vuserLauncher(script);
-    sessions2.on('done', function(report2) {
-      t.assert(Object.keys(report2.errors).length === 1,
-               'Test ran with one error: ' +
-               (Object.keys(report2.errors)[0]));
-      t.end();
+      // Now remove TLS options and rerun - should have an error
+      delete script.config.ws;
+      vuserLauncher(script).then(function(sessions2) {
+        sessions2.on('done', function(report2) {
+          t.assert(Object.keys(report2.errors).length === 1,
+                   'Test ran with one error: ' +
+                   (Object.keys(report2.errors)[0]));
+          t.end();
+        });
+        sessions2.run();
+      });
     });
-    sessions2.run();
+    sessions.run();
   });
-
-  sessions.run();
 });


### PR DESCRIPTION
- List of plugins provided via options.plugins
- runner() will return a Promise or call a callback
- Tests updated to use the new Promise-based interface

**This is a breaking change and will require a semver-major bump.**