### PR TITLE
Make compile use query in options, similar to loadContextSocket

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -273,10 +273,12 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
     let tls = config.tls || {};
     let transports = self.transports || {};
     let path = self.path || {};
+    let query = self.query || {};
     let options = _.extend(
       {},
       tls,
       transports,
+      query,
       path
     );
     ee.emit('started');


### PR DESCRIPTION
To align the compile and loadContextSocket methods' use of the options objects