### PR TITLE
fix: Simplify the way plugins are loaded

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -123,93 +123,69 @@ function runner(script, payload, options, callback) {
   // load plugins:
   //
   let runnerPlugins = [];
+  let requirePaths = [''];
+  if (process.env.ARTILLERY_PLUGIN_PATH) {
+    requirePaths = requirePaths.concat(process.env.ARTILLERY_PLUGIN_PATH.split(':'));
+  }
+
   _.each(runnableScript.config.plugins, function tryToLoadPlugin(pluginConfig, pluginName) {
     let pluginConfigScope = pluginConfig.scope || runnableScript.config.pluginsScope;
     let pluginPrefix = pluginConfigScope ? pluginConfigScope : 'artillery-plugin-';
     let requireString = pluginPrefix + pluginName;
     let Plugin, plugin;
-    try {
-      Plugin = require(requireString);
-      plugin = new Plugin(runnableScript.config, ee);
-      plugin.__name = pluginName;
-    } catch (err) {
 
-      if (process.env.ARTILLERY_PLUGIN_PATH) {
-        let requirePaths = process.env.ARTILLERY_PLUGIN_PATH.split(':');
-        for(let j = 0; j < requirePaths.length; j++) {
-          try {
-            requireString = path.join(process.env.ARTILLERY_PLUGIN_PATH, requireString);
-            Plugin = require(requireString);
-            plugin = new Plugin(runnableScript.config, ee);
-            plugin.__name = pluginName;
-            break; // plugin loaded successfully
-          } catch (err2) {}
+    requirePaths.forEach(function(rp) {
+      try {
+        Plugin = require(path.join(rp, requireString));
+
+        if (typeof Plugin === 'function') {
+          // Plugin interface v1
+          plugin = new Plugin(runnableScript.config, ee);
+          plugin.__name = pluginName;
+        } else if (typeof Plugin === 'object' && typeof Plugin.Plugin === 'function') {
+          // Plugin interface 2+
+          plugin = new Plugin.Plugin(runnableScript, ee);
+          plugin.__name = pluginName;
         }
+      } catch (err) {
+        debug(err);
       }
+    });
 
-      if (!Plugin || !plugin) {
-        console.log(
-            'WARNING: plugin %s specified but module %s could not be loaded',
-            pluginName,
-            requireString);
-        warnings.plugins[pluginName] = {
-          message: 'Could not load',
-          error: err
-        };
-        console.log(err.stack);
-      } else {
-        debug('Plugin %s loaded from %s', pluginName, requireString);
-        runnerPlugins.push(plugin);
-      }
+    if (!Plugin || !plugin) {
+      console.log(
+        'WARNING: plugin %s specified but module %s could not be loaded',
+        pluginName,
+        requireString);
+      warnings.plugins[pluginName] = {
+        message: 'Could not load'
+      };
+    } else {
+      debug('Plugin %s loaded from %s', pluginName, requireString);
+      runnerPlugins.push(plugin);
     }
   });
 
-  debug('opts.plugins = ', JSON.stringify(opts.plugins, null, 4));
   const promise = new Promise(function(resolve, reject) {
-    A.eachSeries(
-      opts.plugins,
-      function iterator(pluginName, next) {
-        let pluginModule = null;
-        try {
-          pluginModule = require(pluginName);
-        } catch (err) {
-          console.log('WARNING: could not load plugin %s', pluginName);
-          console.log(err);
-        }
+    ee.run = function() {
+      let runState = {
+        pendingScenarios: 0,
+        pendingRequests: 0,
+        compiledScenarios: null,
+        scenarioEvents: null,
+        picker: undefined,
+        plugins: runnerPlugins,
+        engines: runnerEngines
+      };
+      debug('run() with: %j', runnableScript);
+      run(runnableScript, ee, opts, runState);
+    };
 
-        if(!pluginModule) {
-          return next(null);
-        }
+    // FIXME: Warnings should be returned from this function instead along with
+    // the event emitter. That will be a breaking change.
+    ee.warnings = warnings;
 
-        let plugin = new pluginModule.Plugin(runnableScript, ee);
-        // TODO: Keep a reference to all plugins somewhere
-        return next(null, { plugin: pluginName, loaded: true });
-      },
-      function allDone(err) {
-        if (err) {
-          console.log(err);
-        }
-
-        ee.run = function() {
-          let runState = {
-            pendingScenarios: 0,
-            pendingRequests: 0,
-            compiledScenarios: null,
-            scenarioEvents: null,
-            picker: undefined,
-            plugins: runnerPlugins,
-            engines: runnerEngines
-          };
-          debug('run() with: %j', runnableScript);
-          run(runnableScript, ee, opts, runState);
-        };
-
-        // FIXME: Warnings should be returned from this function instead along with
-        // the event emitter. That will be a breaking change.
-        ee.warnings = warnings;
-
-        resolve(ee);
-      });
+    resolve(ee);
   });
 
   if (callback && typeof callback === 'function') {
@@ -217,7 +193,6 @@ function runner(script, payload, options, callback) {
   }
 
   return promise;
-
 }
 
 function run(script, ee, options, runState) {


### PR DESCRIPTION
- Same code to handle global plugins and those in
  ARTILLERY_PLUGIN_PATH.
- Support backwards-compatibility with existing plugins that
  expect just the config as the first argument to their constructor
  function.