### PR TITLE
fix missing headers

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -219,7 +219,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           (config.defaults && config.defaults.headers) ?
             config.defaults.headers : {'user-agent': USER_AGENT});
         requestParams.headers = _.extend(defaultHeaders,
-                                         lowcaseKeys(params.headers));
+                                         lowcaseKeys(params.headers), lowcaseKeys(requestParams.headers));
         let headers = _.reduce(requestParams.headers,
                                function(acc, v, k) {
                                  acc[k] = template(v, context);


### PR DESCRIPTION
Hi there,
we tried to add the AWS v4 signing headers using the artillery-plugin-aws-sigv4 and they didn't appear in the request. After debugging we noticed that everything is fine until the line we just edited.

Plugin adds headers but they are simply ignored