### PR TITLE
feat(http): onError hooks

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -48,6 +48,7 @@ HttpEngine.prototype.createScenario = function(scenarioSpec, ee) {
   ensurePropertyIsAList(scenarioSpec, 'afterResponse');
   ensurePropertyIsAList(scenarioSpec, 'beforeScenario');
   ensurePropertyIsAList(scenarioSpec, 'afterScenario');
+  ensurePropertyIsAList(scenarioSpec, 'onError');
 
   // Add scenario-level hooks if needed:
   // For now, just turn them into function steps and insert them
@@ -73,7 +74,8 @@ HttpEngine.prototype.createScenario = function(scenarioSpec, ee) {
   let tasks = _.map(scenarioSpec.flow, function(rs) {
     return self.step(rs, ee, {
       beforeRequest: scenarioSpec.beforeRequest,
-      afterResponse: scenarioSpec.afterResponse
+      afterResponse: scenarioSpec.afterResponse,
+      onError: scenarioSpec.onError
     });
   });
 
@@ -124,6 +126,8 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
   let f = function(context, callback) {
     let method = _.keys(requestSpec)[0].toUpperCase();
     let params = requestSpec[method.toLowerCase()];
+
+    const onErrorHandlers = opts.onError; // only scenario-lever onError handlers are supported
 
     // A special case for when "url" attribute is missing. We need to check for
     // it manually as request.js won't emit an 'error' event when the argument
@@ -309,9 +313,11 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
             context,
             function captured(err, result) {
               if (err) {
-                // end the scenario
-                ee.emit('error', err.message);
-                return callback(err, context);
+                // Run onError hooks and end the scenario:
+                runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(err) {
+                  ee.emit('error', err.message);
+                  return callback(err, context);
+                });
               }
 
               debug('captures and matches:');
@@ -386,8 +392,12 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
 
         if(!requestParams.url) {
           let err = new Error('an URL must be specified');
-          ee.emit('error', err.message);
-          return callback(err, context);
+
+          // Run onError hooks and end the scenario
+          runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(err) {
+            ee.emit('error', err.message);
+            return callback(err, context);
+          });
         }
 
         request(requestParams, maybeCallback)
@@ -409,11 +419,14 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
               callback(null, context);
             } // otherwise called from requestCallback
           }).on('error', function(err) {
-            let errCode = err.code || err.message;
-            ee.emit('error', errCode);
             debug(err);
-            // this aborts the scenario
-            return callback(err, context);
+
+            // Run onError hooks and end the scenario
+            runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(err2) {
+              let errCode = err.code || err.message;
+              ee.emit('error', errCode);
+              return callback(err, context);
+            });
           });
       }); // eachSeries
   };
@@ -471,7 +484,7 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
         }
 
         if (err) {
-          ee.emit('error', err.message);
+          //ee.emit('error', err.message);
           return callback(err, context);
         } else {
           return callback(null, context);
@@ -494,5 +507,19 @@ function maybePrependBase(uri, config) {
 function lowcaseKeys(h) {
   return _.transform(h, function(result, v, k) {
     result[k.toLowerCase()] = v;
+  });
+}
+
+function runOnErrorHooks(functionNames, functions, err, requestParams, context, ee, callback) {
+  async.eachSeries(functionNames, function iteratee(functionName, next) {
+    let processFunc = functions[functionName];
+    processFunc(err, requestParams, context, ee, function(err) {
+      if (err) {
+        return next(err);
+      }
+      return next(null);
+    });
+  }, function done(err) {
+    return callback(err);
   });
 }


### PR DESCRIPTION
- onError hooks can be used to run some code when an error such
  as ECONNRESET occurs before Artillery aborts the scenario
- Only scenario-level onError hooks are supported