### PR TITLE
feat(ws): Add option for calling custom function before sending message

### DIFF
--- a/lib/engine_ws.js
+++ b/lib/engine_ws.js
@@ -48,6 +48,15 @@ WSEngine.prototype.step = function (requestSpec, ee) {
     ee.emit('request');
     let startedAt = process.hrtime();
 
+    if (requestSpec.function) {
+      let processFunc = self.config.processor[requestSpec.function];
+      if (processFunc) {
+        processFunc(context, ee, function () {
+          return callback(null, context);
+        });
+      }
+    }
+
     let payload = template(requestSpec.send, context);
     if (typeof payload === 'object') {
       payload = JSON.stringify(payload);


### PR DESCRIPTION
WebSocket engine has no option to call a function (e. g. for generating data) before sending a message. HTTP and socket.io engine both have this option, so i've extended ws engine with this functionality too.