### PR TITLE
Feature/socketio acknowledgements

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -62,6 +62,10 @@ function isResponseRequired(spec) {
   return (spec.emit && spec.emit.response && spec.emit.response.channel);
 }
 
+function isAcknowledgeRequired(spec) {
+    return (spec.emit && spec.emit.acknowledge);
+}
+
 function processResponse(ee, data, response, context, callback) {
   // Do we have supplied data to validate?
   if (response.data && !deepEqual(data, response.data)) {
@@ -161,6 +165,29 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
       data: template(requestSpec.emit.data, context)
     };
 
+    let endCallback = function (err, context) {
+      if (isAcknowledgeRequired(requestSpec)) {
+        // Acknowledge required so add callback to emit
+        socketio.emit(outgoing.channel, outgoing.data, function (data) {
+          let response = {
+            data: template(requestSpec.emit.acknowledge.data, context),
+            capture: template(requestSpec.emit.acknowledge.capture, context),
+            match: template(requestSpec.emit.acknowledge.match, context)
+          };
+          processResponse(ee, data, response, context, function (err) {
+            if (!err) {
+              markEndTime(ee, context, startedAt);
+            }
+            return callback(err, context);
+          });
+        });
+      } else {
+        // No acknowledge data is expected, so emit without a listener
+        markEndTime(ee, context, startedAt);
+        return callback(null, context);
+      }
+    };
+
     if (isResponseRequired(requestSpec)) {
       let response = {
         channel: template(requestSpec.emit.response.channel, context),
@@ -178,7 +205,7 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
           }
           // Stop listening on the response channel
           socketio.off(response.channel);
-          return callback(err, context);
+          return endCallback(err, context);
         });
       });
       // Send the data on the specified socket.io channel
@@ -194,10 +221,7 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
         }
       }, waitTime);
     } else {
-      // No return data is expected, so emit without a listener
-      socketio.emit(outgoing.channel, outgoing.data);
-      markEndTime(ee, context, startedAt);
-      return callback(null, context);
+      endCallback(null, context);
     }
   };
 

--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -183,6 +183,7 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
         });
       } else {
         // No acknowledge data is expected, so emit without a listener
+        socketio.emit(outgoing.channel, outgoing.data);
         markEndTime(ee, context, startedAt);
         return callback(null, context);
       }


### PR DESCRIPTION
This allows you to test emit acknowledgements in artillery.io as per the socket.io spec.

Reuses code for comparisons/matches where possible.