### PR TITLE
fix(socketio) Fix cookies jar not instantiated in socketio context

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -7,6 +7,7 @@
 const async = require('async');
 const _ = require('lodash');
 
+const request = require('request');
 const io = require('socket.io-client');
 const wildcardPatch = require('socketio-wildcard')(io.Manager);
 
@@ -294,6 +295,7 @@ SocketIoEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
   return function scenario(initialContext, callback) {
     initialContext._successCount = 0;
+    initialContext._jar = request.jar();
     initialContext._pendingRequests = _.size(
         _.reject(scenarioSpec, function(rs) {
           return (typeof rs.think === 'number');

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "bcrypt": "^0.8.5",
+    "cookie-parser": "^1.4.3",
     "csv-parse": "1.0.1",
     "eslint": "^0.24.0",
     "express": "4.13.4",

--- a/test/scripts/cookies_socketio.json
+++ b/test/scripts/cookies_socketio.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+      "target": "http://127.0.0.1:9092",
+      "phases": [
+        {"duration": 10, "arrivalRate": 1}
+      ]
+  },
+  "scenarios": [
+    {
+      "engine": "socketio",
+      "flow": [
+        {"post": {"url": "/setscookie"}},
+        {"get": {"url": "/expectscookie"}}
+      ]
+    }
+  ]
+}

--- a/test/targets/express_socketio.js
+++ b/test/targets/express_socketio.js
@@ -38,3 +38,40 @@ function handler(req, res) {
   res.writeHead(200);
   res.end(JSON.stringify({ key: 'value' }));
 }
+
+var cookieParser = require('cookie-parser');
+var uuid = require('uuid');
+
+var COOKIES = {};
+
+app.post('/setscookie', setsCookie);
+app.get('/expectscookie', cookieParser(), expectsCookie);
+app.get('/_stats', stats);
+
+function setsCookie(req, res) {
+  var newuid = uuid.v4();
+  console.log('setting testCookie.uid to %j', newuid);
+  res.cookie('testCookie', {uid: newuid}).send('ok');
+}
+
+function expectsCookie(req, res) {
+  console.log('req.cookies = %j', req.cookies);
+  console.log('req.cookies.testCookie = %j', req.cookies.testCookie);
+  var cookie = req.cookies.testCookie;
+  if (cookie) {
+    if (COOKIES[cookie.uid]) {
+      COOKIES[cookie.uid]++;
+    } else {
+      COOKIES[cookie.uid] = 1;
+    }
+    return res.send('ok');
+  } else {
+    return res.status(403).send();
+  }
+}
+
+function stats(req, res) {
+  return res.json({
+    cookies: COOKIES
+  });
+}

--- a/test/test_cookies.js
+++ b/test/test_cookies.js
@@ -5,7 +5,7 @@ var runner = require('../lib/runner').runner;
 var l = require('lodash');
 var request = require('request');
 
-test('cookie jar', function(t) {
+test('cookie jar http', function(t) {
   var script = require('./scripts/cookies.json');
   runner(script).then(function(ee) {
     ee.on('done', function(report) {
@@ -20,7 +20,35 @@ test('cookie jar', function(t) {
             return t.fail();
           }
 
-          var ok = l.size(body.cookies) >= report.scenariosCompleted;
+          var ok = report.scenariosCompleted && l.size(body.cookies) === report.scenariosCompleted;
+          t.assert(ok, 'Each scenario had a unique cookie');
+          if (!ok) {
+            console.log(body);
+            console.log(report);
+          }
+          t.end();
+        });
+    });
+    ee.run();
+  });
+});
+
+test('cookie jar socketio', function(t) {
+  var script = require('./scripts/cookies_socketio.json');
+  runner(script).then(function(ee) {
+    ee.on('done', function(report) {
+      request(
+        {
+          method: 'GET',
+          url: 'http://127.0.0.1:9092/_stats',
+          json: true
+        },
+        function(err, res, body) {
+          if (err) {
+            return t.fail();
+          }
+
+          var ok = report.scenariosCompleted && l.size(body.cookies) === report.scenariosCompleted;
           t.assert(ok, 'Each scenario had a unique cookie');
           if (!ok) {
             console.log(body);


### PR DESCRIPTION
Closes shoreditch-ops/artillery#310

It's a bit too difficult to provide test for this as there is apparently no test suite that validates http engine capabilities for socketio engine at all. And setting that up would be too big of a change for the scope of this PR as it needs either reorganizing tests or doing a lot of copy-pasting in both test scenarios and test infra code.