### PR TITLE
HTTP(S) agent changes

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -248,16 +248,12 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           requestParams.auth.pass = template(requestParams.auth.pass, context);
         }
 
-        if (config.http2) {
-          requestParams.http2 = true;
+        if (!self.pool) {
+          requestParams.agent = context._agent;
         } else {
-          if (!self.pool) {
-            requestParams.agent = context._agent;
-          } else {
-
-            requestParams.pool = self.pool;
-          }
+          requestParams.pool = self.pool;
         }
+
 
         let url = maybePrependBase(template(requestParams.uri || requestParams.url, context), config);
 
@@ -440,28 +436,27 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
 
     initialContext._jar = request.jar();
 
-    if (!config.http2) {
-      if (!self.pool) {
-        let agentOpts = {
-          keepAlive: true,
-          keepAliveMsecs: 1000,
-          maxSockets: 1,
-          maxFreeSockets: 1
-        };
+    if (!self.pool) {
+      let agentOpts = {
+        keepAlive: true,
+        keepAliveMsecs: 1000,
+        maxSockets: 1,
+        maxFreeSockets: 1
+      };
 
-        // FIXME: This won't work if we have a pool - needs to be set in agentOptions
-        // in request params
-        if ((/^https/i).test(config.target)) {
-          if (tls.pfx) {
-            // FIXME: Path needs to be resolved relative to Artillery's cwd
-            agentOpts.pfx = fs.readFileSync(tls.pfx);
-          }
-          initialContext._agent = new https.Agent(agentOpts);
-        } else {
-          initialContext._agent = new http.Agent(agentOpts);
+      // FIXME: This won't work if we have a pool - needs to be set in agentOptions
+      // in request params
+      if ((/^https/i).test(config.target)) {
+        if (tls.pfx) {
+          // FIXME: Path needs to be resolved relative to Artillery's cwd
+          agentOpts.pfx = fs.readFileSync(tls.pfx);
         }
+        initialContext._agent = new https.Agent(agentOpts);
+      } else {
+        initialContext._agent = new http.Agent(agentOpts);
       }
     }
+
 
     let steps = _.flatten([
       function zero(cb) {

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -248,13 +248,6 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           requestParams.auth.pass = template(requestParams.auth.pass, context);
         }
 
-        if (!self.pool) {
-          requestParams.agent = context._agent;
-        } else {
-          requestParams.pool = self.pool;
-        }
-
-
         let url = maybePrependBase(template(requestParams.uri || requestParams.url, context), config);
 
         if (requestParams.uri) {
@@ -264,6 +257,16 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
         }
 
         requestParams.url = url;
+
+        if (!self.pool) {
+          if ((/^https/i).test(requestParams.url)) {
+            requestParams.agent = context._httpsAgent;
+          } else {
+            requestParams.agent = context._httpAgent;
+          }
+        } else {
+          requestParams.pool = self.pool;
+        }
 
         function requestCallback(err, res, body) {
           if (err) {
@@ -451,11 +454,8 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
         maxFreeSockets: maxSockets
       };
 
-      if ((/^https/i).test(config.target)) {
-        initialContext._agent = new https.Agent(agentOpts);
-      } else {
-        initialContext._agent = new http.Agent(agentOpts);
-      }
+      initialContext._httpAgent = new http.Agent(agentOpts);
+      initialContext._httpsAgent = new https.Agent(agentOpts);
     }
 
 
@@ -471,8 +471,11 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
       steps,
       function scenarioWaterfallCb(err, context) {
         // If the connection was refused we might not have a context
-        if (context && context._agent) {
-          context._agent.destroy();
+        if (context && context._httpAgent) {
+          context._httpAgent.destroy();
+        }
+        if (context && context._httpsAgent) {
+          context._httpsAgent.destroy();
         }
 
         if (err) {

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -451,13 +451,7 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
         maxFreeSockets: maxSockets
       };
 
-      // FIXME: This won't work if we have a pool - needs to be set in agentOptions
-      // in request params
       if ((/^https/i).test(config.target)) {
-        if (tls.pfx) {
-          // FIXME: Path needs to be resolved relative to Artillery's cwd
-          agentOpts.pfx = fs.readFileSync(tls.pfx);
-        }
         initialContext._agent = new https.Agent(agentOpts);
       } else {
         initialContext._agent = new http.Agent(agentOpts);

--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -435,13 +435,20 @@ HttpEngine.prototype.compile = function compile(tasks, scenarioSpec, ee) {
     initialContext._successCount = 0;
 
     initialContext._jar = request.jar();
-
+    let keepAliveMsec = 30 * 1000;
+    if (self.config.http && self.config.http.keepAlive) {
+      keepAliveMsec = self.config.http.keepAlive * 1000;
+    }
+    let maxSockets = 1;
+    if (self.config.http && self.config.http.maxSockets) {
+      maxSockets = self.config.http.maxSockets;
+    }
     if (!self.pool) {
       let agentOpts = {
         keepAlive: true,
-        keepAliveMsecs: 1000,
-        maxSockets: 1,
-        maxFreeSockets: 1
+        keepAliveMsecs: keepAliveMsec,
+        maxSockets: maxSockets,
+        maxFreeSockets: maxSockets
       };
 
       // FIXME: This won't work if we have a pool - needs to be set in agentOptions


### PR DESCRIPTION
- Default keep alive timeout increase to 30s
- Keep alive timeout and max sockets are now configurable
- HTTP and HTTPS requests may now be mixed in the same scenario