### PR TITLE
Separate async error from original error in onError handling

### DIFF
--- a/lib/engine_http.js
+++ b/lib/engine_http.js
@@ -309,7 +309,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
             function captured(err, result) {
               if (err) {
                 // Run onError hooks and end the scenario:
-                runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(err) {
+                runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(asyncErr) {
                   ee.emit('error', err.message);
                   return callback(err, context);
                 });
@@ -389,7 +389,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           let err = new Error('an URL must be specified');
 
           // Run onError hooks and end the scenario
-          runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(err) {
+          runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(asyncErr) {
             ee.emit('error', err.message);
             return callback(err, context);
           });
@@ -417,7 +417,7 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
             debug(err);
 
             // Run onError hooks and end the scenario
-            runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(err2) {
+            runOnErrorHooks(onErrorHandlers, config.processor, err, requestParams, context, ee, function(asyncErr) {
               let errCode = err.code || err.message;
               ee.emit('error', errCode);
               return callback(err, context);
@@ -508,13 +508,13 @@ function lowcaseKeys(h) {
 function runOnErrorHooks(functionNames, functions, err, requestParams, context, ee, callback) {
   async.eachSeries(functionNames, function iteratee(functionName, next) {
     let processFunc = functions[functionName];
-    processFunc(err, requestParams, context, ee, function(err) {
-      if (err) {
-        return next(err);
+    processFunc(err, requestParams, context, ee, function(asyncErr) {
+      if (asyncErr) {
+        return next(asyncErr);
       }
       return next(null);
     });
-  }, function done(err) {
-    return callback(err);
+  }, function done(asyncErr) {
+    return callback(asyncErr);
   });
 }


### PR DESCRIPTION
The original error needs to be kept separately from any potential errors that
might occur while processing the onError hooks.

This was already done in one place where `err2` was being used.

If all onError callbacks complete successfully then `async.eachSeries` calls its
callback without an error value.

One way to repro this problem is to set up a `beforeRequest` hook that sets
`request.url = null`.  Artillery then errors in a spot where it tries to access
the original error but actually accesses the non-existent async error.

NOTE: It does seem like something out to pay attention to any async errors. That
might be good to tackle in a separate PR though?