### PR TITLE
Variables can now be grouped into sequences that can be used together

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -373,7 +373,7 @@ function createContext(script) {
   // inline variables
   //
   if (script.config.variables) {
-    _.each(script.config.variables, function(v, k) {
+    var processVariables = function(v, k) {
       let val;
       if (_.isArray(v)) {
         val = _.sample(v);
@@ -381,7 +381,17 @@ function createContext(script) {
         val = v;
       }
       result.vars[k] = val;
-    });
+    };
+
+    var variables = script.config.variables;
+
+    if (_.isArray(variables)) {
+      var variableSet = _.sample(variables);
+      _.each(variableSet, processVariables);
+    } else {
+      _.each(variables, processVariables);
+    }
+
   }
   result._uid = uuid.v4();
   return result;


### PR DESCRIPTION
Variables can now be grouped into sequences that can be used together in a scenario.

**PROBLEM**:
When you want a set of variables to be used together on requests. For example you have an auth header and xsrf token that are tied to a user and need them to go together. Currently the variables section uses lodash sample to randomly pick the value across the possible values.

**CURRENT**:
Currently variables can be defined like this (where the value is pulled at random):
```
variables:
  xsrf: 
    - "dflfjsdlkjlwkwekkjlkjr"
    - "poipoiwerisdfsdf"
  auth:
    - "234rfewrew3243"
    - "765765dfgdf454"
```

**SOLUTION**:
But also now like this:
```
variables:
  - 
    xsrf: "dflfjsdlkjlwkwekkjlkjr"
    auth: "234rfewrew3243"
  - 
    xsrf: "poipoiwerisdfsdf"
    auth: "765765dfgdf454"
```

Where auth and xsrf values are pulled out together in sets.
