### PR TITLE
feat: Allow for additional plugin configuration via environment

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -142,6 +142,20 @@ function runner(script, payload, options, callback) {
 
   debug('require paths: ', requirePaths);
 
+  runnableScript.config.plugins = runnableScript.config.plugins || {};
+
+  if (process.env.ARTILLERY_PLUGINS) {
+    let additionalPlugins = {};
+    try {
+      additionalPlugins = JSON.parse(process.env.ARTILLERY_PLUGINS);
+    } catch (ignoreErr) {
+      debug(ignoreErr);
+    }
+    runnableScript.config.plugins = Object.assign(
+      runnableScript.config.plugins,
+      additionalPlugins);
+  }
+
   _.each(runnableScript.config.plugins, function tryToLoadPlugin(pluginConfig, pluginName) {
     let pluginConfigScope = pluginConfig.scope || runnableScript.config.pluginsScope;
     let pluginPrefix = pluginConfigScope ? pluginConfigScope : 'artillery-plugin-';


### PR DESCRIPTION
`ARTILLERY_PLUGIN` may be set to a stringified JSON object which
describes additional plugins that Artillery should try to load.