### PR TITLE
feat(socketio): Pass through config.socketio through

### DIFF
--- a/lib/engine_socketio.js
+++ b/lib/engine_socketio.js
@@ -21,26 +21,7 @@ module.exports = SocketIoEngine;
 function SocketIoEngine(script) {
   this.config = script.config;
 
-  if (script.config.socketio) {
-    if (script.config.socketio.transports) {
-      this.transports = {
-        transports: script.config.socketio.transports
-      };
-    }
-
-    if (script.config.socketio.query) {
-      this.query = {
-        query: script.config.socketio.query
-      };
-    }
-
-	if (script.config.socketio.path) {
-      this.path = {
-        path: script.config.socketio.path
-      };
-    }
-  }
-
+  this.socketioOpts = this.config.socketio || {};
   this.httpDelegate = new EngineHttp(script);
 }
 
@@ -276,15 +257,12 @@ SocketIoEngine.prototype.loadContextSocket = function(namespace, context, cb) {
   if(!context.sockets[namespace]) {
     let target = this.config.target + namespace;
     let tls = this.config.tls || {};
-    let transports = this.transports || {};
-    let path = template(this.path || {}, context);
-    let query = template(this.query || {}, context);
+
+    const socketioOpts = template(this.socketioOpts, context);
     let options = _.extend(
       {},
-      tls,
-      transports,
-      query,
-      path
+      socketioOpts, // templated
+      tls
     );
 
     let socket = io(target, options);


### PR DESCRIPTION
Any option supported by Socket.io may now be set via `config.socketio` in the Artillery script.