### PR TITLE
Adds script.scenario.path to ws engine

### DIFF
--- a/lib/engine_ws.js
+++ b/lib/engine_ws.js
@@ -26,7 +26,7 @@ WSEngine.prototype.createScenario = function(scenarioSpec, ee) {
     return self.step(rs, ee);
   });
 
-  return self.compile(tasks, scenarioSpec.flow, ee);
+  return self.compile(tasks, scenarioSpec, ee);
 };
 
 WSEngine.prototype.step = function (requestSpec, ee) {
@@ -98,7 +98,15 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
       ee.emit('started');
 
-      let ws = new WebSocket(config.target, options);
+      let url = config.target;
+
+      // if url path is included in scenario spec, append path to url
+      if (scenarioSpec.path) {
+        let path = template(scenarioSpec.path, initialContext);
+        url = url + path;
+      }
+
+      let ws = new WebSocket(url, options);
       ws.on('open', function() {
         initialContext.ws = ws;
         return callback(null, initialContext);
@@ -112,7 +120,7 @@ WSEngine.prototype.compile = function (tasks, scenarioSpec, ee) {
 
     initialContext._successCount = 0;
     initialContext._pendingRequests = _.size(
-      _.reject(scenarioSpec, function(rs) {
+      _.reject(scenarioSpec.flow, function(rs) {
         return (typeof rs.think === 'number');
       }));
 

--- a/test/targets/simple_ws.js
+++ b/test/targets/simple_ws.js
@@ -4,6 +4,7 @@ var wss = new WebSocketServer({host: '127.0.0.1', port: 9090});
 var MESSAGE_COUNT = 0;
 var CONNECTION_COUNT = 0;
 
+/*
 wss.on('connection', function connection(ws) {
   CONNECTION_COUNT++;
   console.log('+ connection');
@@ -20,3 +21,13 @@ setInterval(function() {
   console.log('CONNECTION_COUNT [ws] = %s', CONNECTION_COUNT);
   console.log('MESSAGE_COUNT    [ws] = %s', MESSAGE_COUNT);
 }, 5 * 1000);
+*/
+
+module.exports = createServer;
+
+function createServer(port) {
+  port = port || 9090;
+
+  var wss = new WebSocketServer({host: '127.0.0.1', port: port});
+  return wss;
+}

--- a/test/unit/engine_ws.test.js
+++ b/test/unit/engine_ws.test.js
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const EventEmitter = require('events');
+const test = require('tape');
+const WsEngine = require('../../lib/engine_ws');
+
+const createServer = require('../targets/simple_ws');
+
+const port = 3003;
+const script = {
+  config: {
+    target: 'ws://localhost:' + port,
+    variables: {
+      id: [ "a" ]
+    }
+  },
+  scenarios: [
+    {
+      name: 'Whatever',
+      path: '/path?id={{ id }}',
+      flow: [
+        {
+          send: "message"
+        }
+      ]
+    }
+  ]
+};
+
+test('WebsocketEngineInterface', function(t) {
+  t.plan(2);
+
+  const engine = new WsEngine(script);
+  const ee = new EventEmitter();
+
+  const runScenario = engine.createScenario(script.scenarios[0], ee);
+
+  t.assert(engine, 'Can init the engine');
+  t.assert(typeof runScenario === 'function', 'Can create a virtual user function');
+
+  t.end();
+});
+
+test('Websocket connection at configured and templated path', function(t) {
+  t.plan(3);
+
+  const target = createServer(port);
+
+  const engine = new WsEngine(script);
+  const ee = new EventEmitter();
+
+  const runScenario = engine.createScenario(script.scenarios[0], ee);
+
+  target.on('connection', function connection(ws) {
+    t.assert(true, 'Connected to target');
+  });
+
+  const initialContext = { vars: { id: "some-var" } };
+  runScenario(initialContext, function userDone(err, finalContext) {
+    t.assert(!err, 'Scenario didn\'t err');
+    t.assert(finalContext.ws.url === 'ws://localhost:3003/path?id=some-var');
+  });
+});


### PR DESCRIPTION
I have a room-based real-time communication server that uses the URL path to specify the roomID and a URL query param `?id=` to specify a clientID.  I've implemented it to prevent two clients with the same clientID from being in the same Room at once.  For example,

```
[0] peer1 makes request to wss://my-rtc-server-ho.st/room1?id=client1
[a]   client1 at peer1 connected to room1
[1] peer2 makes request to wss://my-rtc-server-ho.st/room1?id=client1
[a]   client1 at peer1 disconnected from room1
[b]   client1 at peer2 connected to room1
```

To load test this, I need to be able to change the WebSocket client's path.  This PR adds the ability to do so.

### Example

Suppose I've added a csv file with random IDs.
```csv
id
BATb3eukXu5V3e7y9eBWWvicNLiQZjN0
5IDZQ1pJCOdGSl1V3PhnBZfJcBBVCMy6
lSThKruBW1wZDJgZkmEWlTdR2k787QVf
RvxsCYgJ4CtvHPV0VMwAGmc7b39ooQoe
5seju5S9jHyi22UJ6EVdJyEOw2H9qFuS
...
```

I use this to test concurrent connections to a single room:

```yml
config:
  payload:
    path: "./random-ids.csv"
    fields:
      - "id"
    order: "sequence"
  target: "ws://my-rtc-server-ho.st"
  phases:
    - duration: 20
      arrivalRate: 10
scenarios:
  - engine: "ws"
    path: "/room1?id={{ id }}"
    flow:
      - send: '{"token":":)"}' # auth
      - think: 1
      - send: '{"some":"json"}'
```

I hope this is helpful.  Thanks!